### PR TITLE
Store states checksums its want

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Resolver -->
     <dependency>

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordUtils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordUtils.java
@@ -9,26 +9,26 @@ package eu.maveniverse.maven.njord.shared;
 
 import static java.util.Objects.requireNonNull;
 
-import eu.maveniverse.maven.njord.shared.impl.repository.DefaultArtifactStoreManager;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManager;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import org.eclipse.aether.RepositorySystemSession;
 
 public final class NjordUtils {
     private NjordUtils() {}
 
     public static boolean lazyInitConfig(
-            RepositorySystemSession repositorySystemSession, Supplier<Config> configSupplier) {
+            RepositorySystemSession repositorySystemSession,
+            Config config,
+            Function<Config, ArtifactStoreManager> artifactStoreManagerFactory) {
         requireNonNull(repositorySystemSession, "repositorySystemSession");
-        requireNonNull(configSupplier, "configSupplier");
-        Config config = mayGetConfig(repositorySystemSession).orElse(null);
+        requireNonNull(config, "config");
+        Config oldConfig = mayGetConfig(repositorySystemSession).orElse(null);
         boolean result = false;
-        if (config == null) {
-            config = configSupplier.get();
+        if (oldConfig == null) {
             setConfig(repositorySystemSession, config);
             if (config.enabled()) {
-                setArtifactStoreManager(repositorySystemSession, new DefaultArtifactStoreManager(config));
+                setArtifactStoreManager(repositorySystemSession, artifactStoreManagerFactory.apply(config));
                 result = true;
             }
         }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStore.java
@@ -1,6 +1,7 @@
 package eu.maveniverse.maven.njord.shared.impl.repository;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 import eu.maveniverse.maven.njord.shared.impl.DirectoryLocker;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
@@ -14,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -22,11 +24,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 
 public class DefaultArtifactStore implements ArtifactStore {
@@ -34,6 +40,7 @@ public class DefaultArtifactStore implements ArtifactStore {
     private final Instant created;
     private final RepositoryMode repositoryMode;
     private final boolean allowRedeploy;
+    private final List<ChecksumAlgorithmFactory> checksumAlgorithmFactories;
     private final Path basedir;
 
     private final AtomicBoolean closed;
@@ -41,7 +48,8 @@ public class DefaultArtifactStore implements ArtifactStore {
     /**
      * Creates instance out for existing store.
      */
-    public DefaultArtifactStore(Path basedir) throws IOException {
+    public DefaultArtifactStore(Path basedir, ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector)
+            throws IOException {
         DirectoryLocker.INSTANCE.lockDirectory(basedir, false);
         Properties properties = new Properties();
         Path meta = basedir.resolve(".meta").resolve("repository.properties");
@@ -55,6 +63,10 @@ public class DefaultArtifactStore implements ArtifactStore {
         this.repositoryMode = requireNonNull(
                 RepositoryMode.valueOf(properties.getProperty("repositoryMode")), "RepositoryMode not provided");
         this.allowRedeploy = Boolean.parseBoolean(properties.getProperty("allowRedeploy"));
+        this.checksumAlgorithmFactories = checksumAlgorithmFactorySelector.selectList(Arrays.stream(
+                        properties.getProperty("checksumAlgorithmFactories").split(","))
+                .filter(s -> !s.trim().isEmpty())
+                .collect(toList()));
         this.basedir = requireNonNull(basedir);
         this.closed = new AtomicBoolean(false);
     }
@@ -62,7 +74,12 @@ public class DefaultArtifactStore implements ArtifactStore {
     /**
      * Creates and inits brand-new store.
      */
-    public DefaultArtifactStore(String name, RepositoryMode repositoryMode, boolean allowRedeploy, Path basedir)
+    public DefaultArtifactStore(
+            String name,
+            RepositoryMode repositoryMode,
+            boolean allowRedeploy,
+            List<ChecksumAlgorithmFactory> checksumAlgorithmFactories,
+            Path basedir)
             throws IOException {
         Files.createDirectories(basedir); // if brand new, we must create it first
         DirectoryLocker.INSTANCE.lockDirectory(basedir, true);
@@ -71,6 +88,7 @@ public class DefaultArtifactStore implements ArtifactStore {
             this.created = Instant.now();
             this.repositoryMode = requireNonNull(repositoryMode);
             this.allowRedeploy = allowRedeploy;
+            this.checksumAlgorithmFactories = requireNonNull(checksumAlgorithmFactories);
             this.basedir = requireNonNull(basedir);
             this.closed = new AtomicBoolean(false);
 
@@ -79,6 +97,11 @@ public class DefaultArtifactStore implements ArtifactStore {
             properties.put("created", Long.toString(created.toEpochMilli()));
             properties.put("repositoryMode", repositoryMode.name());
             properties.put("allowRedeploy", Boolean.toString(allowRedeploy));
+            properties.put(
+                    "checksumAlgorithmFactories",
+                    checksumAlgorithmFactories.stream()
+                            .map(ChecksumAlgorithmFactory::getName)
+                            .collect(Collectors.joining(",")));
             Path meta = basedir.resolve(".meta").resolve("repository.properties");
             Files.createDirectories(meta.getParent());
             try (OutputStream out = Files.newOutputStream(meta, StandardOpenOption.CREATE_NEW)) {
@@ -112,6 +135,12 @@ public class DefaultArtifactStore implements ArtifactStore {
     public boolean allowRedeploy() {
         checkClosed();
         return allowRedeploy;
+    }
+
+    @Override
+    public List<ChecksumAlgorithmFactory> checksumAlgorithmFactories() {
+        checkClosed();
+        return List.copyOf(checksumAlgorithmFactories);
     }
 
     @Override
@@ -149,6 +178,19 @@ public class DefaultArtifactStore implements ArtifactStore {
     }
 
     @Override
+    public RepositorySystemSession storeRepositorySession(RepositorySystemSession session) {
+        checkClosed();
+        requireNonNull(session);
+        DefaultRepositorySystemSession session2 = new DefaultRepositorySystemSession(session);
+        session2.setUserProperty(
+                "aether.checksums.algorithms",
+                checksumAlgorithmFactories().stream()
+                        .map(ChecksumAlgorithmFactory::getName)
+                        .collect(Collectors.joining(",")));
+        return session2;
+    }
+
+    @Override
     public RemoteRepository storeRemoteRepository() {
         return new RemoteRepository.Builder(name(), "default", "file://" + basedir()).build();
     }
@@ -169,12 +211,13 @@ public class DefaultArtifactStore implements ArtifactStore {
             throw new IllegalArgumentException("Passed in metadata must have set existing file");
         }
         // check RepositoryMode (snapshot vs release)
-        boolean expected = repositoryMode != RepositoryMode.RELEASE;
+        boolean expected = repositoryMode() != RepositoryMode.RELEASE;
         if (artifacts.stream().anyMatch(a -> a.isSnapshot() != expected)) {
             throw new IllegalArgumentException("Passed in artifacts repository policy mismatch");
         }
         // check DeployMode (already exists)
-        if (!allowRedeploy && artifacts.stream().anyMatch(a -> Files.isRegularFile(basedir.resolve(artifactPath(a))))) {
+        if (!allowRedeploy()
+                && artifacts.stream().anyMatch(a -> Files.isRegularFile(basedir.resolve(artifactPath(a))))) {
             throw new IllegalArgumentException("Redeployment is forbidden (artifact already exists)");
         }
 

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreManager.java
@@ -87,7 +87,10 @@ public class DefaultArtifactStoreManager implements ArtifactStoreManager {
                 name,
                 template.repositoryMode(),
                 template.allowRedeploy(),
-                checksumAlgorithmFactorySelector.selectList(template.checksumAlgorithmFactories()),
+                template.checksumAlgorithmFactories().isPresent()
+                        ? checksumAlgorithmFactorySelector.selectList(
+                                template.checksumAlgorithmFactories().orElseThrow())
+                        : null,
                 config.basedir().resolve(name));
     }
 

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreManagerFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreManagerFactory.java
@@ -1,0 +1,27 @@
+package eu.maveniverse.maven.njord.shared.impl.repository;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.njord.shared.Config;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManager;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManagerFactory;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
+
+@Singleton
+@Named
+public class DefaultArtifactStoreManagerFactory implements ArtifactStoreManagerFactory {
+    private final ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector;
+
+    @Inject
+    public DefaultArtifactStoreManagerFactory(ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector) {
+        this.checksumAlgorithmFactorySelector = requireNonNull(checksumAlgorithmFactorySelector);
+    }
+
+    @Override
+    public ArtifactStoreManager create(Config config) {
+        return new DefaultArtifactStoreManager(config, checksumAlgorithmFactorySelector);
+    }
+}

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
@@ -5,9 +5,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 
 public interface ArtifactStore extends Closeable {
     /**
@@ -32,6 +35,11 @@ public interface ArtifactStore extends Closeable {
     boolean allowRedeploy();
 
     /**
+     * The checksum algorithm factories this store uses.
+     */
+    List<ChecksumAlgorithmFactory> checksumAlgorithmFactories();
+
+    /**
      * Index of artifacts in this store, never {@code null}.
      */
     Collection<Artifact> artifacts();
@@ -47,7 +55,16 @@ public interface ArtifactStore extends Closeable {
     Path basedir();
 
     /**
+     * Customizes the session to access this store.
+     *
+     * @see #storeRemoteRepository()
+     */
+    RepositorySystemSession storeRepositorySession(RepositorySystemSession session);
+
+    /**
      * The Resolver remote repository access to underlying store.
+     *
+     * @see #storeRepositorySession(RepositorySystemSession)
      */
     RemoteRepository storeRemoteRepository();
 

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
@@ -35,9 +36,9 @@ public interface ArtifactStore extends Closeable {
     boolean allowRedeploy();
 
     /**
-     * The checksum algorithm factories this store uses.
+     * The checksum algorithm factories this store uses, or empty if globally configured are wanted.
      */
-    List<ChecksumAlgorithmFactory> checksumAlgorithmFactories();
+    Optional<List<ChecksumAlgorithmFactory>> checksumAlgorithmFactories();
 
     /**
      * Index of artifacts in this store, never {@code null}.

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManagerFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManagerFactory.java
@@ -1,0 +1,10 @@
+package eu.maveniverse.maven.njord.shared.store;
+
+import eu.maveniverse.maven.njord.shared.Config;
+
+public interface ArtifactStoreManagerFactory {
+    /**
+     * Creates instance of artifact store manager.
+     */
+    ArtifactStoreManager create(Config config);
+}

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
@@ -2,7 +2,14 @@ package eu.maveniverse.maven.njord.shared.store;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
 public interface ArtifactStoreTemplate {
+    /**
+     * The Maven default checksum algorithms.
+     */
+    List<String> DEFAULT_CHECKSUM_ALGORITHMS = List.of("SHA-1", "MD5");
+
     /**
      * Template name.
      */
@@ -25,25 +32,41 @@ public interface ArtifactStoreTemplate {
      */
     boolean allowRedeploy();
 
-    ArtifactStoreTemplate RELEASE = create("release", RepositoryMode.RELEASE, false);
+    /**
+     * The checksum algorithm factories this template created store uses.
+     */
+    List<String> checksumAlgorithmFactories();
 
-    ArtifactStoreTemplate RELEASE_REDEPLOY = create("release-redeploy", RepositoryMode.RELEASE, true);
+    ArtifactStoreTemplate RELEASE = create("release", RepositoryMode.RELEASE, false, DEFAULT_CHECKSUM_ALGORITHMS);
 
-    ArtifactStoreTemplate SNAPSHOT = create("snapshot", RepositoryMode.SNAPSHOT, false);
+    ArtifactStoreTemplate RELEASE_REDEPLOY =
+            create("release-redeploy", RepositoryMode.RELEASE, true, DEFAULT_CHECKSUM_ALGORITHMS);
 
-    static ArtifactStoreTemplate create(String name, RepositoryMode repositoryMode, boolean allowRedeploy) {
-        return new Impl(name, repositoryMode, allowRedeploy);
+    ArtifactStoreTemplate SNAPSHOT = create("snapshot", RepositoryMode.SNAPSHOT, false, DEFAULT_CHECKSUM_ALGORITHMS);
+
+    static ArtifactStoreTemplate create(
+            String name,
+            RepositoryMode repositoryMode,
+            boolean allowRedeploy,
+            List<String> checksumAlgorithmFactories) {
+        return new Impl(name, repositoryMode, allowRedeploy, checksumAlgorithmFactories);
     }
 
     class Impl implements ArtifactStoreTemplate {
         private final String name;
         private final RepositoryMode repositoryMode;
         private final boolean allowRedeploy;
+        private final List<String> checksumAlgorithmFactories;
 
-        private Impl(String name, RepositoryMode repositoryMode, boolean allowRedeploy) {
+        private Impl(
+                String name,
+                RepositoryMode repositoryMode,
+                boolean allowRedeploy,
+                List<String> checksumAlgorithmFactories) {
             this.name = requireNonNull(name);
             this.repositoryMode = requireNonNull(repositoryMode);
             this.allowRedeploy = allowRedeploy;
+            this.checksumAlgorithmFactories = requireNonNull(checksumAlgorithmFactories);
         }
 
         @Override
@@ -59,6 +82,11 @@ public interface ArtifactStoreTemplate {
         @Override
         public boolean allowRedeploy() {
             return allowRedeploy;
+        }
+
+        @Override
+        public List<String> checksumAlgorithmFactories() {
+            return List.copyOf(checksumAlgorithmFactories);
         }
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
@@ -3,6 +3,7 @@ package eu.maveniverse.maven.njord.shared.store;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ArtifactStoreTemplate {
     /**
@@ -33,9 +34,9 @@ public interface ArtifactStoreTemplate {
     boolean allowRedeploy();
 
     /**
-     * The checksum algorithm factories this template created store uses.
+     * The checksum algorithm factories this template created store uses, or empty if globally configured are wanted.
      */
-    List<String> checksumAlgorithmFactories();
+    Optional<List<String>> checksumAlgorithmFactories();
 
     ArtifactStoreTemplate RELEASE = create("release", RepositoryMode.RELEASE, false, DEFAULT_CHECKSUM_ALGORITHMS);
 
@@ -66,7 +67,7 @@ public interface ArtifactStoreTemplate {
             this.name = requireNonNull(name);
             this.repositoryMode = requireNonNull(repositoryMode);
             this.allowRedeploy = allowRedeploy;
-            this.checksumAlgorithmFactories = requireNonNull(checksumAlgorithmFactories);
+            this.checksumAlgorithmFactories = checksumAlgorithmFactories;
         }
 
         @Override
@@ -85,8 +86,12 @@ public interface ArtifactStoreTemplate {
         }
 
         @Override
-        public List<String> checksumAlgorithmFactories() {
-            return List.copyOf(checksumAlgorithmFactories);
+        public Optional<List<String>> checksumAlgorithmFactories() {
+            if (checksumAlgorithmFactories == null) {
+                return Optional.empty();
+            } else {
+                return Optional.of(checksumAlgorithmFactories);
+            }
         }
     }
 }

--- a/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordRepositoryConnectorFactory.java
+++ b/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordRepositoryConnectorFactory.java
@@ -58,7 +58,8 @@ public class NjordRepositoryConnectorFactory implements RepositoryConnectorFacto
                 return new NjordRepositoryConnector(
                         artifactStore,
                         repository,
-                        basicRepositoryConnectorFactory.newInstance(session, artifactStore.storeRemoteRepository()));
+                        basicRepositoryConnectorFactory.newInstance(
+                                artifactStore.storeRepositorySession(session), artifactStore.storeRemoteRepository()));
             }
         }
         throw new NoRepositoryConnectorException(repository);

--- a/it/extension-its/src/it/basic/invoker.properties
+++ b/it/extension-its/src/it/basic/invoker.properties
@@ -1,5 +1,5 @@
 # 0th: clean
-invoker.goals.1 = -V -e njord:drop-all -Dyes
+invoker.goals.1 = -V -e njord:${project.version}:drop-all -Dyes
 # 1st: deploy/stage once
 invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release -l first.log
 # 2nd: deploy/stage twice
@@ -7,4 +7,4 @@ invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release
 # 3rd: deploy/stage twice
 invoker.goals.4 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release -l third.log
 # 4th: list
-invoker.goals.5 = -V -e njord:list -l fourth.log
+invoker.goals.5 = -V -e njord:${project.version}:list -l fourth.log

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
@@ -3,6 +3,7 @@ package eu.maveniverse.maven.njord.plugin3;
 import eu.maveniverse.maven.njord.shared.Config;
 import eu.maveniverse.maven.njord.shared.NjordUtils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManager;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManagerFactory;
 import java.io.IOException;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -24,15 +25,21 @@ public abstract class NjordMojoSupport extends AbstractMojo {
     @Inject
     protected RepositorySystem repositorySystem;
 
+    @Inject
+    protected ArtifactStoreManagerFactory artifactStoreManagerFactory;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         RepositorySystemSession session = mavenSession.getRepositorySession();
-        NjordUtils.lazyInitConfig(session, () -> Config.defaults()
-                .userProperties(session.getUserProperties())
-                .systemProperties(session.getSystemProperties())
-                .build());
+        NjordUtils.lazyInitConfig(
+                session,
+                Config.defaults()
+                        .userProperties(session.getUserProperties())
+                        .systemProperties(session.getSystemProperties())
+                        .build(),
+                artifactStoreManagerFactory::create);
         Optional<ArtifactStoreManager> artifactStoreManager = NjordUtils.mayGetArtifactStoreManager(session);
-        if (!artifactStoreManager.isPresent()) {
+        if (artifactStoreManager.isEmpty()) {
             logger.warn("Not configured or explicitly disabled");
             return;
         }


### PR DESCRIPTION
Template may override globally configured resolver checksums (making this config "per store") or just use globally configured ones. This configuration is then carried over to store instance and obeyed. Contains more, as things are becoming Sisu enabled as well for proper injection of resolver bits.

Fixes #8