### PR TITLE
Transportable bundle

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-    <extension>
-        <groupId>eu.maveniverse.maven.njord</groupId>
-        <artifactId>extension</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </extension>
-</extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.3.1-SNAPSHOT</version>
+    </extension>
+</extensions>

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordSession.java
@@ -11,9 +11,9 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManager;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreMerger;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.Optional;
@@ -30,9 +30,9 @@ public interface NjordSession extends Closeable {
     ArtifactStoreManager artifactStoreManager();
 
     /**
-     * Creates store exporter. Returned instance must be closed, ideally in try-with-resource.
+     * Creates store writer. Returned instance must be closed, ideally in try-with-resource.
      */
-    ArtifactStoreExporter createArtifactStoreExporter();
+    ArtifactStoreWriter createArtifactStoreWriter();
 
     /**
      * Creates store merger. Returned instance must be closed, ideally in try-with-resource.

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSession.java
@@ -11,16 +11,16 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
-import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreExporterFactory;
 import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreMergerFactory;
+import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreWriterFactory;
 import eu.maveniverse.maven.njord.shared.impl.factories.InternalArtifactStoreManagerFactory;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherFactory;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreManager;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreMerger;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
@@ -31,19 +31,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DefaultNjordSession extends CloseableConfigSupport<SessionConfig> implements NjordSession {
     private final InternalArtifactStoreManager internalArtifactStoreManager;
-    private final ArtifactStoreExporterFactory artifactStoreExporterFactory;
+    private final ArtifactStoreWriterFactory artifactStoreWriterFactory;
     private final ArtifactStoreMergerFactory artifactStoreMergerFactory;
     private final Map<String, ArtifactStorePublisherFactory> artifactStorePublisherFactories;
 
     public DefaultNjordSession(
             SessionConfig sessionConfig,
             InternalArtifactStoreManagerFactory internalArtifactStoreManagerFactory,
-            ArtifactStoreExporterFactory artifactStoreExporterFactory,
+            ArtifactStoreWriterFactory artifactStoreWriterFactory,
             ArtifactStoreMergerFactory artifactStoreMergerFactory,
             Map<String, ArtifactStorePublisherFactory> artifactStorePublisherFactories) {
         super(sessionConfig);
         this.internalArtifactStoreManager = internalArtifactStoreManagerFactory.create(sessionConfig);
-        this.artifactStoreExporterFactory = requireNonNull(artifactStoreExporterFactory);
+        this.artifactStoreWriterFactory = requireNonNull(artifactStoreWriterFactory);
         this.artifactStoreMergerFactory = requireNonNull(artifactStoreMergerFactory);
         this.artifactStorePublisherFactories = requireNonNull(artifactStorePublisherFactories);
     }
@@ -60,9 +60,9 @@ public class DefaultNjordSession extends CloseableConfigSupport<SessionConfig> i
     }
 
     @Override
-    public ArtifactStoreExporter createArtifactStoreExporter() {
+    public ArtifactStoreWriter createArtifactStoreWriter() {
         checkClosed();
-        return artifactStoreExporterFactory.create(sessionConfig());
+        return artifactStoreWriterFactory.create(sessionConfig());
     }
 
     @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSessionFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSessionFactory.java
@@ -12,8 +12,8 @@ import static java.util.Objects.requireNonNull;
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.NjordSessionFactory;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
-import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreExporterFactory;
 import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreMergerFactory;
+import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreWriterFactory;
 import eu.maveniverse.maven.njord.shared.impl.factories.InternalArtifactStoreManagerFactory;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherFactory;
 import java.util.Map;
@@ -25,18 +25,18 @@ import javax.inject.Singleton;
 @Named
 public class DefaultNjordSessionFactory<C> implements NjordSessionFactory {
     private final InternalArtifactStoreManagerFactory internalArtifactStoreManagerFactory;
-    private final ArtifactStoreExporterFactory artifactStoreExporterFactory;
+    private final ArtifactStoreWriterFactory artifactStoreWriterFactory;
     private final ArtifactStoreMergerFactory artifactStoreMergerFactory;
     private final Map<String, ArtifactStorePublisherFactory> artifactStorePublisherFactories;
 
     @Inject
     public DefaultNjordSessionFactory(
             InternalArtifactStoreManagerFactory internalArtifactStoreManagerFactory,
-            ArtifactStoreExporterFactory artifactStoreExporterFactory,
+            ArtifactStoreWriterFactory artifactStoreWriterFactory,
             ArtifactStoreMergerFactory artifactStoreMergerFactory,
             Map<String, ArtifactStorePublisherFactory> artifactStorePublisherFactories) {
         this.internalArtifactStoreManagerFactory = requireNonNull(internalArtifactStoreManagerFactory);
-        this.artifactStoreExporterFactory = requireNonNull(artifactStoreExporterFactory);
+        this.artifactStoreWriterFactory = requireNonNull(artifactStoreWriterFactory);
         this.artifactStoreMergerFactory = requireNonNull(artifactStoreMergerFactory);
         this.artifactStorePublisherFactories = requireNonNull(artifactStorePublisherFactories);
     }
@@ -46,7 +46,7 @@ public class DefaultNjordSessionFactory<C> implements NjordSessionFactory {
         return new DefaultNjordSession(
                 sessionConfig,
                 internalArtifactStoreManagerFactory,
-                artifactStoreExporterFactory,
+                artifactStoreWriterFactory,
                 artifactStoreMergerFactory,
                 artifactStorePublisherFactories);
     }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/FileUtils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/FileUtils.java
@@ -163,7 +163,8 @@ public final class FileUtils {
     /**
      * Copies directory recursively.
      */
-    public static void copyRecursively(Path from, Path to, Predicate<Path> predicate) throws IOException {
+    public static void copyRecursively(Path from, Path to, Predicate<Path> predicate, boolean overwrite)
+            throws IOException {
         Files.walkFileTree(from, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
@@ -180,7 +181,12 @@ public final class FileUtils {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 if (predicate.test(file)) {
                     Path target = to.resolve(from.relativize(file).toString());
-                    Files.copy(file, target, StandardCopyOption.COPY_ATTRIBUTES);
+                    if (overwrite) {
+                        Files.copy(
+                                file, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+                    } else {
+                        Files.copy(file, target, StandardCopyOption.COPY_ATTRIBUTES);
+                    }
                 }
                 return FileVisitResult.CONTINUE;
             }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/factories/ArtifactStoreWriterFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/factories/ArtifactStoreWriterFactory.java
@@ -8,6 +8,6 @@
 package eu.maveniverse.maven.njord.shared.impl.factories;
 
 import eu.maveniverse.maven.njord.shared.SessionConfigAwareFactory;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 
-public interface ArtifactStoreExporterFactory extends SessionConfigAwareFactory<ArtifactStoreExporter> {}
+public interface ArtifactStoreWriterFactory extends SessionConfigAwareFactory<ArtifactStoreWriter> {}

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStore.java
@@ -13,6 +13,7 @@ import eu.maveniverse.maven.njord.shared.impl.CloseableSupport;
 import eu.maveniverse.maven.njord.shared.impl.DirectoryLocker;
 import eu.maveniverse.maven.njord.shared.impl.FileUtils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +43,7 @@ import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 
 public class DefaultArtifactStore extends CloseableSupport implements ArtifactStore {
     private final String name;
+    private final ArtifactStoreTemplate template;
     private final Instant created;
     private final RepositoryMode repositoryMode;
     private final boolean allowRedeploy;
@@ -51,6 +53,7 @@ public class DefaultArtifactStore extends CloseableSupport implements ArtifactSt
 
     public DefaultArtifactStore(
             String name,
+            ArtifactStoreTemplate template,
             Instant created,
             RepositoryMode repositoryMode,
             boolean allowRedeploy,
@@ -58,6 +61,7 @@ public class DefaultArtifactStore extends CloseableSupport implements ArtifactSt
             List<String> omitChecksumsForExtensions,
             Path basedir) {
         this.name = requireNonNull(name);
+        this.template = requireNonNull(template);
         this.created = requireNonNull(created);
         this.repositoryMode = requireNonNull(repositoryMode);
         this.allowRedeploy = allowRedeploy;
@@ -74,6 +78,11 @@ public class DefaultArtifactStore extends CloseableSupport implements ArtifactSt
     @Override
     public String name() {
         return name;
+    }
+
+    @Override
+    public ArtifactStoreTemplate template() {
+        return template;
     }
 
     @Override
@@ -198,6 +207,16 @@ public class DefaultArtifactStore extends CloseableSupport implements ArtifactSt
         }
         FileUtils.copyRecursively(
                 basedir(), directory, p -> !p.getFileName().toString().startsWith("."));
+    }
+
+    @Override
+    public void exportTo(Path directory) throws IOException {
+        requireNonNull(directory);
+        if (!Files.isDirectory(directory)) {
+            throw new IOException("Directory does not exist");
+        }
+        FileUtils.copyRecursively(
+                basedir(), directory, p -> !p.getFileName().toString().startsWith(".lock"));
     }
 
     @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStore.java
@@ -206,17 +206,10 @@ public class DefaultArtifactStore extends CloseableSupport implements ArtifactSt
             throw new IOException("Directory does not exist");
         }
         FileUtils.copyRecursively(
-                basedir(), directory, p -> !p.getFileName().toString().startsWith("."));
-    }
-
-    @Override
-    public void exportTo(Path directory) throws IOException {
-        requireNonNull(directory);
-        if (!Files.isDirectory(directory)) {
-            throw new IOException("Directory does not exist");
-        }
-        FileUtils.copyRecursively(
-                basedir(), directory, p -> !p.getFileName().toString().startsWith(".lock"));
+                basedir(),
+                directory,
+                p -> p.getFileName() == null || !p.getFileName().toString().startsWith("."),
+                false);
     }
 
     @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreExporter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreExporter.java
@@ -28,12 +28,12 @@ public class DefaultArtifactStoreExporter extends CloseableConfigSupport<Session
     }
 
     @Override
-    public Path exportAsDirectory(ArtifactStore artifactStore, Path directory) throws IOException {
+    public Path exportAsDirectory(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
         requireNonNull(artifactStore);
-        requireNonNull(directory);
+        requireNonNull(outputDirectory);
         checkClosed();
 
-        Path targetDirectory = Config.getCanonicalPath(directory);
+        Path targetDirectory = Config.getCanonicalPath(outputDirectory);
         if (Files.exists(targetDirectory)) {
             throw new IOException("Exporting to existing directory not supported");
         }
@@ -42,12 +42,12 @@ public class DefaultArtifactStoreExporter extends CloseableConfigSupport<Session
     }
 
     @Override
-    public Path exportAsBundle(ArtifactStore artifactStore, Path directory) throws IOException {
+    public Path exportAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
         requireNonNull(artifactStore);
-        requireNonNull(directory);
+        requireNonNull(outputDirectory);
         checkClosed();
 
-        Path targetDirectory = Config.getCanonicalPath(directory);
+        Path targetDirectory = Config.getCanonicalPath(outputDirectory);
         if (!Files.isDirectory(targetDirectory)) {
             Files.createDirectories(targetDirectory);
         }
@@ -58,6 +58,27 @@ public class DefaultArtifactStoreExporter extends CloseableConfigSupport<Session
         try (FileSystem fs = FileSystems.newFileSystem(bundleFile, Map.of("create", "true"), null)) {
             Path root = fs.getPath("/");
             artifactStore.writeTo(root);
+        }
+        return bundleFile;
+    }
+
+    @Override
+    public Path exportAsTransportableBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
+        requireNonNull(artifactStore);
+        requireNonNull(outputDirectory);
+        checkClosed();
+
+        Path targetDirectory = Config.getCanonicalPath(outputDirectory);
+        if (!Files.isDirectory(targetDirectory)) {
+            Files.createDirectories(targetDirectory);
+        }
+        Path bundleFile = targetDirectory.resolve(artifactStore.name() + ".zip");
+        if (Files.exists(bundleFile)) {
+            throw new IOException("Exporting to existing bundle ZIP not supported");
+        }
+        try (FileSystem fs = FileSystems.newFileSystem(bundleFile, Map.of("create", "true"), null)) {
+            Path root = fs.getPath("/");
+            artifactStore.exportTo(root);
         }
         return bundleFile;
     }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreWriter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreWriter.java
@@ -13,7 +13,7 @@ import eu.maveniverse.maven.njord.shared.Config;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.impl.CloseableConfigSupport;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -21,14 +21,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-public class DefaultArtifactStoreExporter extends CloseableConfigSupport<SessionConfig>
-        implements ArtifactStoreExporter {
-    public DefaultArtifactStoreExporter(SessionConfig sessionConfig) {
+public class DefaultArtifactStoreWriter extends CloseableConfigSupport<SessionConfig> implements ArtifactStoreWriter {
+    public DefaultArtifactStoreWriter(SessionConfig sessionConfig) {
         super(sessionConfig);
     }
 
     @Override
-    public Path exportAsDirectory(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
+    public Path writeAsDirectory(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
         requireNonNull(artifactStore);
         requireNonNull(outputDirectory);
         checkClosed();
@@ -42,7 +41,7 @@ public class DefaultArtifactStoreExporter extends CloseableConfigSupport<Session
     }
 
     @Override
-    public Path exportAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
+    public Path writeAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
         requireNonNull(artifactStore);
         requireNonNull(outputDirectory);
         checkClosed();
@@ -58,27 +57,6 @@ public class DefaultArtifactStoreExporter extends CloseableConfigSupport<Session
         try (FileSystem fs = FileSystems.newFileSystem(bundleFile, Map.of("create", "true"), null)) {
             Path root = fs.getPath("/");
             artifactStore.writeTo(root);
-        }
-        return bundleFile;
-    }
-
-    @Override
-    public Path exportAsTransportableBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
-        requireNonNull(artifactStore);
-        requireNonNull(outputDirectory);
-        checkClosed();
-
-        Path targetDirectory = Config.getCanonicalPath(outputDirectory);
-        if (!Files.isDirectory(targetDirectory)) {
-            Files.createDirectories(targetDirectory);
-        }
-        Path bundleFile = targetDirectory.resolve(artifactStore.name() + ".zip");
-        if (Files.exists(bundleFile)) {
-            throw new IOException("Exporting to existing bundle ZIP not supported");
-        }
-        try (FileSystem fs = FileSystems.newFileSystem(bundleFile, Map.of("create", "true"), null)) {
-            Path root = fs.getPath("/");
-            artifactStore.exportTo(root);
         }
         return bundleFile;
     }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreWriterFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultArtifactStoreWriterFactory.java
@@ -8,16 +8,16 @@
 package eu.maveniverse.maven.njord.shared.impl.repository;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
-import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreExporterFactory;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
+import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreWriterFactory;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 @Singleton
 @Named
-public class DefaultArtifactStoreExporterFactory implements ArtifactStoreExporterFactory {
+public class DefaultArtifactStoreWriterFactory implements ArtifactStoreWriterFactory {
     @Override
-    public ArtifactStoreExporter create(SessionConfig sessionConfig) {
-        return new DefaultArtifactStoreExporter(sessionConfig);
+    public ArtifactStoreWriter create(SessionConfig sessionConfig) {
+        return new DefaultArtifactStoreWriter(sessionConfig);
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultInternalArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultInternalArtifactStoreManager.java
@@ -130,6 +130,7 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
 
         Properties properties = new Properties();
         properties.put("name", name);
+        properties.put("templateName", template.name());
         properties.put("created", Long.toString(created.toEpochMilli()));
         properties.put("repositoryMode", repositoryMode.name());
         properties.put("allowRedeploy", Boolean.toString(allowRedeploy));
@@ -147,6 +148,7 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
 
         return new DefaultArtifactStore(
                 name,
+                template,
                 created,
                 repositoryMode,
                 allowRedeploy,
@@ -188,6 +190,7 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
 
             return new DefaultArtifactStore(
                     properties.getProperty("name"),
+                    templates.get(properties.getProperty("templateName")),
                     Instant.ofEpochMilli(Long.parseLong(properties.getProperty("created"))),
                     RepositoryMode.valueOf(properties.getProperty("repositoryMode")),
                     Boolean.parseBoolean(properties.getProperty("allowRedeploy")),

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultInternalArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/repository/DefaultInternalArtifactStoreManager.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.impl.repository;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
+import eu.maveniverse.maven.njord.shared.Config;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.impl.CloseableConfigSupport;
 import eu.maveniverse.maven.njord.shared.impl.DirectoryLocker;
@@ -21,6 +22,8 @@ import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -76,7 +79,7 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
         requireNonNull(name);
         checkClosed();
 
-        return Optional.ofNullable(existingArtifactStore(name));
+        return Optional.ofNullable(loadExistingArtifactStore(name));
     }
 
     @Override
@@ -93,68 +96,12 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
         return List.copyOf(templates.values());
     }
 
-    // copied as while it is public in Resolver 2 is not in Resolver 1
-    private static final String CONFIG_PROP_CHECKSUMS_ALGORITHMS = "aether.checksums.algorithms";
-    private static final String DEFAULT_CHECKSUMS_ALGORITHMS = "SHA-1,MD5";
-
-    private static final String CONFIG_PROP_OMIT_CHECKSUMS_FOR_EXTENSIONS =
-            "aether.checksums.omitChecksumsForExtensions";
-    private static final String DEFAULT_OMIT_CHECKSUMS_FOR_EXTENSIONS = ".asc,.sigstore";
-
     @Override
     public ArtifactStore createArtifactStore(ArtifactStoreTemplate template) throws IOException {
         requireNonNull(template);
         checkClosed();
 
-        String name = newArtifactStoreName(template.prefix());
-        Path basedir = config.config().basedir().resolve(name);
-        Files.createDirectories(basedir);
-        DirectoryLocker.INSTANCE.lockDirectory(basedir, true);
-        Instant created = Instant.now();
-        RepositoryMode repositoryMode = template.repositoryMode();
-        boolean allowRedeploy = template.allowRedeploy();
-        List<ChecksumAlgorithmFactory> checksumAlgorithmFactories = template.checksumAlgorithmFactories()
-                        .isPresent()
-                ? checksumAlgorithmFactorySelector.selectList(
-                        template.checksumAlgorithmFactories().orElseThrow())
-                : checksumAlgorithmFactorySelector.selectList(
-                        ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
-                                config.session(), DEFAULT_CHECKSUMS_ALGORITHMS, CONFIG_PROP_CHECKSUMS_ALGORITHMS)));
-        List<String> omitChecksumsForExtensions =
-                template.omitChecksumsForExtensions().isPresent()
-                        ? template.omitChecksumsForExtensions().orElseThrow()
-                        : ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
-                                config.session(),
-                                DEFAULT_OMIT_CHECKSUMS_FOR_EXTENSIONS,
-                                CONFIG_PROP_OMIT_CHECKSUMS_FOR_EXTENSIONS));
-
-        Properties properties = new Properties();
-        properties.put("name", name);
-        properties.put("templateName", template.name());
-        properties.put("created", Long.toString(created.toEpochMilli()));
-        properties.put("repositoryMode", repositoryMode.name());
-        properties.put("allowRedeploy", Boolean.toString(allowRedeploy));
-        properties.put(
-                "checksumAlgorithmFactories",
-                checksumAlgorithmFactories.stream()
-                        .map(ChecksumAlgorithmFactory::getName)
-                        .collect(Collectors.joining(",")));
-        properties.put("omitChecksumsForExtensions", String.join(",", omitChecksumsForExtensions));
-        Path meta = basedir.resolve(".meta").resolve("repository.properties");
-        Files.createDirectories(meta.getParent());
-        try (OutputStream out = Files.newOutputStream(meta, StandardOpenOption.CREATE_NEW)) {
-            properties.store(out, null);
-        }
-
-        return new DefaultArtifactStore(
-                name,
-                template,
-                created,
-                repositoryMode,
-                allowRedeploy,
-                checksumAlgorithmFactories,
-                omitChecksumsForExtensions,
-                basedir);
+        return createNewArtifactStore(template);
     }
 
     @Override
@@ -178,7 +125,89 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
         return false;
     }
 
-    private DefaultArtifactStore existingArtifactStore(String name) throws IOException {
+    @Override
+    public Path exportTo(ArtifactStore artifactStore, Path file) throws IOException {
+        requireNonNull(artifactStore);
+        requireNonNull(file);
+        checkClosed();
+
+        if (!(artifactStore instanceof DefaultArtifactStore)) {
+            throw new IllegalArgumentException("Unsupported store type: " + artifactStore.getClass());
+        }
+
+        Path targetDirectory = Config.getCanonicalPath(file);
+        Path bundleFile = targetDirectory;
+        if (Files.isDirectory(targetDirectory)) {
+            bundleFile = targetDirectory.resolve(artifactStore.name() + ".zip");
+        } else if (!Files.isDirectory(targetDirectory.getFileName())) {
+            throw new IllegalArgumentException("Target parent directory does not exists");
+        }
+        if (Files.exists(bundleFile)) {
+            throw new IOException("Exporting to existing bundle ZIP not supported");
+        }
+        try (FileSystem fs = FileSystems.newFileSystem(bundleFile, Map.of("create", "true"), null)) {
+            Path root = fs.getPath("/");
+            if (!Files.isDirectory(root)) {
+                throw new IOException("Directory does not exist");
+            }
+            FileUtils.copyRecursively(
+                    ((DefaultArtifactStore) artifactStore).basedir(),
+                    root,
+                    p -> p.getFileName() == null || !p.getFileName().toString().startsWith(".lock"),
+                    false);
+        }
+        return bundleFile;
+    }
+
+    @Override
+    public ArtifactStore importFrom(Path file) throws IOException {
+        requireNonNull(file);
+        checkClosed();
+
+        if (!Files.isRegularFile(file)) {
+            throw new IllegalArgumentException("File does not exist");
+        }
+        Path storeSource = Config.getCanonicalPath(file);
+        String storeName = null;
+        Path storeBasedir = null;
+        try (FileSystem fs = FileSystems.newFileSystem(storeSource, Map.of("create", "false"), null)) {
+            Path repositoryProperties = fs.getPath("/", ".meta", "repository.properties");
+            if (Files.exists(repositoryProperties)) {
+                Properties properties = new Properties();
+                try (InputStream in = Files.newInputStream(repositoryProperties)) {
+                    properties.load(in);
+                }
+                ArtifactStoreTemplate template = templates.get(properties.getProperty("templateName"));
+                if (template == null) {
+                    throw new IOException("Template not found: " + properties.getProperty("templateName"));
+                }
+                try (DefaultArtifactStore artifactStore = createNewArtifactStore(template)) {
+                    storeName = artifactStore.name();
+                    storeBasedir = artifactStore.basedir();
+                    FileUtils.copyRecursively(
+                            fs.getPath("/"),
+                            artifactStore.basedir(),
+                            p -> p.getFileName() == null
+                                    || !p.getFileName().toString().startsWith(".lock"),
+                            true);
+                }
+                // fix name
+                properties.clear();
+                Path newStoreProperties = storeBasedir.resolve(".meta").resolve("repository.properties");
+                try (InputStream in = Files.newInputStream(newStoreProperties)) {
+                    properties.load(in);
+                }
+                properties.setProperty("name", storeName);
+                try (OutputStream out =
+                        Files.newOutputStream(newStoreProperties, StandardOpenOption.TRUNCATE_EXISTING)) {
+                    properties.store(out, null);
+                }
+            }
+        }
+        return loadExistingArtifactStore(storeName);
+    }
+
+    private DefaultArtifactStore loadExistingArtifactStore(String name) throws IOException {
         Path basedir = config.config().basedir().resolve(name);
         if (Files.isDirectory(basedir)) {
             DirectoryLocker.INSTANCE.lockDirectory(basedir, false);
@@ -207,6 +236,66 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
                     basedir);
         }
         return null;
+    }
+
+    // copied as while it is public in Resolver 2 is not in Resolver 1
+    private static final String CONFIG_PROP_CHECKSUMS_ALGORITHMS = "aether.checksums.algorithms";
+    private static final String DEFAULT_CHECKSUMS_ALGORITHMS = "SHA-1,MD5";
+
+    private static final String CONFIG_PROP_OMIT_CHECKSUMS_FOR_EXTENSIONS =
+            "aether.checksums.omitChecksumsForExtensions";
+    private static final String DEFAULT_OMIT_CHECKSUMS_FOR_EXTENSIONS = ".asc,.sigstore";
+
+    private DefaultArtifactStore createNewArtifactStore(ArtifactStoreTemplate template) throws IOException {
+        String name = newArtifactStoreName(template.prefix());
+        Path basedir = config.config().basedir().resolve(name);
+        Files.createDirectories(basedir);
+        DirectoryLocker.INSTANCE.lockDirectory(basedir, true);
+        Instant created = Instant.now();
+        RepositoryMode repositoryMode = template.repositoryMode();
+        boolean allowRedeploy = template.allowRedeploy();
+        List<ChecksumAlgorithmFactory> checksumAlgorithmFactories = template.checksumAlgorithmFactories()
+                        .isPresent()
+                ? checksumAlgorithmFactorySelector.selectList(
+                        template.checksumAlgorithmFactories().orElseThrow())
+                : checksumAlgorithmFactorySelector.selectList(
+                        ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
+                                config.session(), DEFAULT_CHECKSUMS_ALGORITHMS, CONFIG_PROP_CHECKSUMS_ALGORITHMS)));
+        List<String> omitChecksumsForExtensions =
+                template.omitChecksumsForExtensions().isPresent()
+                        ? template.omitChecksumsForExtensions().orElseThrow()
+                        : ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
+                                config.session(),
+                                DEFAULT_OMIT_CHECKSUMS_FOR_EXTENSIONS,
+                                CONFIG_PROP_OMIT_CHECKSUMS_FOR_EXTENSIONS));
+
+        Properties properties = new Properties();
+        properties.setProperty("name", name);
+        properties.setProperty("templateName", template.name());
+        properties.setProperty("created", Long.toString(created.toEpochMilli()));
+        properties.setProperty("repositoryMode", repositoryMode.name());
+        properties.setProperty("allowRedeploy", Boolean.toString(allowRedeploy));
+        properties.setProperty(
+                "checksumAlgorithmFactories",
+                checksumAlgorithmFactories.stream()
+                        .map(ChecksumAlgorithmFactory::getName)
+                        .collect(Collectors.joining(",")));
+        properties.setProperty("omitChecksumsForExtensions", String.join(",", omitChecksumsForExtensions));
+        Path meta = basedir.resolve(".meta").resolve("repository.properties");
+        Files.createDirectories(meta.getParent());
+        try (OutputStream out = Files.newOutputStream(meta, StandardOpenOption.CREATE_NEW)) {
+            properties.store(out, null);
+        }
+
+        return new DefaultArtifactStore(
+                name,
+                template,
+                created,
+                repositoryMode,
+                allowRedeploy,
+                checksumAlgorithmFactories,
+                omitChecksumsForExtensions,
+                basedir);
     }
 
     private String newArtifactStoreName(String prefix) throws IOException {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStoreRequirements.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStoreRequirements.java
@@ -26,30 +26,57 @@ public interface ArtifactStoreRequirements {
     /**
      * Returns the list of mandatory checksum algorithms.
      */
-    Optional<List<ChecksumAlgorithmFactory>> mandatoryChecksumAlgorithms();
+    default Optional<List<ChecksumAlgorithmFactory>> mandatoryChecksumAlgorithms() {
+        return Optional.empty();
+    }
 
     /**
      * Returns the list of supported and optional checksum algorithms.
      */
-    Optional<List<ChecksumAlgorithmFactory>> optionalChecksumAlgorithms();
+    default Optional<List<ChecksumAlgorithmFactory>> optionalChecksumAlgorithms() {
+        return Optional.empty();
+    }
 
     /**
      * Returns the list of mandatory signature types.
      */
-    Optional<List<SignatureType>> mandatorySignatureTypes();
+    default Optional<List<SignatureType>> mandatorySignatureTypes() {
+        return Optional.empty();
+    }
 
     /**
      * Returns the list of supported and optional signature types.
      */
-    Optional<List<SignatureType>> optionalSignatureTypes();
+    default Optional<List<SignatureType>> optionalSignatureTypes() {
+        return Optional.empty();
+    }
 
     /**
      * The validator that must be applied to release store before publishing.
      */
-    Optional<ArtifactStoreValidator> releaseValidator();
+    default Optional<ArtifactStoreValidator> releaseValidator() {
+        return Optional.empty();
+    }
 
     /**
      * The validator that must be applied to snapshot store before publishing.
      */
-    Optional<ArtifactStoreValidator> snapshotValidator();
+    default Optional<ArtifactStoreValidator> snapshotValidator() {
+        return Optional.empty();
+    }
+
+    /**
+     * No requirements.
+     */
+    ArtifactStoreRequirements NONE = new ArtifactStoreRequirements() {
+        @Override
+        public String name() {
+            return "none";
+        }
+
+        @Override
+        public String description() {
+            return "No requirements";
+        }
+    };
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
@@ -28,6 +28,11 @@ public interface ArtifactStore extends Closeable {
     String name();
 
     /**
+     * The template used to create this store.
+     */
+    ArtifactStoreTemplate template();
+
+    /**
      * Timestamp when this store was created, never {@code null}.
      */
     Instant created();
@@ -101,6 +106,12 @@ public interface ArtifactStore extends Closeable {
      * Writes out the whole store to given directory retaining the layout of the store. The directory must exist.
      */
     void writeTo(Path directory) throws IOException;
+
+    /**
+     * Exports out the whole store to given directory retaining the layout of the store and all the metadata.
+     * The directory must exist.
+     */
+    void exportTo(Path directory) throws IOException;
 
     /**
      * Content modifying operation handle. Caller must close this instance, even if operation is canceled.

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
@@ -108,12 +108,6 @@ public interface ArtifactStore extends Closeable {
     void writeTo(Path directory) throws IOException;
 
     /**
-     * Exports out the whole store to given directory retaining the layout of the store and all the metadata.
-     * The directory must exist.
-     */
-    void exportTo(Path directory) throws IOException;
-
-    /**
      * Content modifying operation handle. Caller must close this instance, even if operation is canceled.
      */
     interface Operation extends Closeable {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreExporter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreExporter.java
@@ -21,4 +21,9 @@ public interface ArtifactStoreExporter extends Closeable {
      * Exports store as ZIP bundle. Returns the ZIP file.
      */
     Path exportAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
+
+    /**
+     * Exports store as "transportable" Njord bundle. Returns the ZIP file.
+     */
+    Path exportAsTransportableBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.shared.store;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -41,4 +42,15 @@ public interface ArtifactStoreManager {
      * Fully deletes store.
      */
     boolean dropArtifactStore(String name) throws IOException;
+
+    /**
+     * Exports store as "transportable" Njord bundle. The file may be existing directory, in which case name of the
+     * resulting file will be store name, or non-existing file (with existing parents). Returns the bundle file.
+     */
+    Path exportTo(ArtifactStore artifactStore, Path file) throws IOException;
+
+    /**
+     * Imports the whole store to from "transportable" Njord bundle. The file must exist.
+     */
+    ArtifactStore importFrom(Path file) throws IOException;
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreWriter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreWriter.java
@@ -11,19 +11,14 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public interface ArtifactStoreExporter extends Closeable {
+public interface ArtifactStoreWriter extends Closeable {
     /**
      * Exports store as directory hierarchy using Maven remote repository layout. Returns the root directory.
      */
-    Path exportAsDirectory(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
+    Path writeAsDirectory(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
 
     /**
      * Exports store as ZIP bundle. Returns the ZIP file.
      */
-    Path exportAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
-
-    /**
-     * Exports store as "transportable" Njord bundle. Returns the ZIP file.
-     */
-    Path exportAsTransportableBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
+    Path writeAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
 }

--- a/it/extension-its/src/it/export-import/.mvn/extensions.xml
+++ b/it/extension-its/src/it/export-import/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/export-import/README.md
+++ b/it/extension-its/src/it/export-import/README.md
@@ -1,0 +1,3 @@
+# Import-Export
+
+Tests import and export usage of Njord.

--- a/it/extension-its/src/it/export-import/invoker.properties
+++ b/it/extension-its/src/it/export-import/invoker.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# 0th: clean
+invoker.goals.1 = -V -e njord:${project.version}:drop-all -Dyes
+# 1st: deploy/stage to release
+invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-sca -l first.log
+# 2nd: export
+invoker.goals.3 = -V -e njord:${project.version}:export -Dstore=release-sca-00001 -l second.log
+# 3rd: import
+invoker.goals.4 = -V -e njord:${project.version}:import -Dfile=release-sca-00001.zip -l third.log
+# 4th: list
+invoker.goals.5 = -V -e njord:${project.version}:list -l fourth.log

--- a/it/extension-its/src/it/export-import/pom.xml
+++ b/it/extension-its/src/it/export-import/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.njord.it</groupId>
+    <artifactId>merge-release</artifactId>
+    <version>1.0.0</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <!-- Build MUST BE reproducible -->
+        <project.build.outputTimestamp>2025-04-17T00:00:00Z</project.build.outputTimestamp>
+        <attach-classifier>first</attach-classifier>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-fake</id>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/merge-release-1.0.0.jar</file>
+                                    <type>jar</type>
+                                    <classifier>${attach-classifier}</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/it/extension-its/src/it/export-import/verify.groovy
+++ b/it/extension-its/src/it/export-import/verify.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File firstLog = new File( basedir, 'first.log' )
+assert firstLog.exists()
+var first = firstLog.text
+
+File secondLog = new File( basedir, 'second.log' )
+assert secondLog.exists()
+var second = secondLog.text
+
+File thirdLog = new File( basedir, 'third.log' )
+assert thirdLog.exists()
+var third = thirdLog.text
+
+File fourthLog = new File( basedir, 'fourth.log' )
+assert fourthLog.exists()
+var fourth = fourthLog.text
+
+// Lets make strict assertion
+// Also, consider Maven 3 vs 4 diff: they resolve differently; do not assert counts
+
+// first run:
+assert first.contains("[INFO] Njord ${projectVersion} session created")
+assert first.contains('[INFO] Using alternate deployment repository id::njord:release-sca')
+
+// second run:
+assert second.contains("[INFO] Njord ${projectVersion} session created")
+assert second.contains('[INFO] Exporting store release-sca-00001 to')
+assert second.contains('[INFO] Exported to ')
+
+// third run:
+assert third.contains("[INFO] Njord ${projectVersion} session created")
+assert third.contains('[INFO] Importing store from')
+assert third.contains('[INFO] Imported to ')
+
+// fourth run:
+assert fourth.contains("[INFO] Njord ${projectVersion} session created")
+assert fourth.contains('[INFO] Total of 2 ArtifactStore.')

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ImportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ImportMojo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.njord.plugin3;
+
+import eu.maveniverse.maven.njord.shared.Config;
+import eu.maveniverse.maven.njord.shared.NjordSession;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Imports a store from "transportable bundle".
+ */
+@Mojo(name = "import", threadSafe = true, requiresProject = false)
+public class ImportMojo extends NjordMojoSupport {
+    @Parameter(required = true, property = "file")
+    private String file;
+
+    @Override
+    protected void doExecute(NjordSession ns) throws IOException, MojoExecutionException {
+        Path source = Config.getCanonicalPath(Path.of(file).toAbsolutePath());
+        if (!Files.exists(source)) {
+            throw new MojoExecutionException("Import file not found: " + file);
+        }
+        logger.info("Importing store from {}", source);
+        try (ArtifactStore artifactStore = ns.artifactStoreManager().importFrom(source)) {
+            logger.info("Imported to " + artifactStore);
+        }
+    }
+}

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteBundleMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteBundleMojo.java
@@ -10,7 +10,7 @@ package eu.maveniverse.maven.njord.plugin3;
 import eu.maveniverse.maven.njord.shared.Config;
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,11 +20,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * Exports a store as "bundle" ZIP to given path. The ZIP file has remote repository layout and contains all the
+ * Write out a store as "bundle" ZIP to given path. The ZIP file has remote repository layout and contains all the
  * artifacts and metadata.
  */
-@Mojo(name = "export-bundle", threadSafe = true, requiresProject = false)
-public class ExportBundleMojo extends NjordMojoSupport {
+@Mojo(name = "write-bundle", threadSafe = true, requiresProject = false)
+public class WriteBundleMojo extends NjordMojoSupport {
     @Parameter(required = true, property = "store")
     private String store;
 
@@ -40,11 +40,11 @@ public class ExportBundleMojo extends NjordMojoSupport {
                 Files.createDirectories(targetDirectory);
             }
             Path result;
-            logger.info("Exporting store {} as bundle to {}", store, directory);
-            try (ArtifactStoreExporter artifactStoreExporter = ns.createArtifactStoreExporter()) {
-                result = artifactStoreExporter.exportAsBundle(storeOptional.orElseThrow(), targetDirectory);
+            logger.info("Writing store {} as bundle to {}", store, directory);
+            try (ArtifactStoreWriter artifactStoreWriter = ns.createArtifactStoreWriter()) {
+                result = artifactStoreWriter.writeAsBundle(storeOptional.orElseThrow(), targetDirectory);
             }
-            logger.info("Exported to " + result);
+            logger.info("Written to " + result);
         } else {
             logger.warn("ArtifactStore with given name not found");
         }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteMojo.java
@@ -10,7 +10,9 @@ package eu.maveniverse.maven.njord.plugin3;
 import eu.maveniverse.maven.njord.shared.Config;
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -18,24 +20,30 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * Export out a store as "transportable bundle" to given path.
+ * Writes out a store as "remote Maven repository" directory structure to given directory.
  */
-@Mojo(name = "export", threadSafe = true, requiresProject = false)
-public class ExportMojo extends NjordMojoSupport {
+@Mojo(name = "write", threadSafe = true, requiresProject = false)
+public class WriteMojo extends NjordMojoSupport {
     @Parameter(required = true, property = "store")
     private String store;
 
-    @Parameter(required = true, property = "path", defaultValue = ".")
-    private String path;
+    @Parameter(required = true, property = "directory")
+    private String directory;
 
     @Override
     protected void doExecute(NjordSession ns) throws IOException, MojoExecutionException {
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
         if (storeOptional.isPresent()) {
-            Path targetPath = Config.getCanonicalPath(Path.of(path).toAbsolutePath());
-            logger.info("Exporting store {} to {}", store, targetPath);
-            Path bundle = ns.artifactStoreManager().exportTo(storeOptional.orElseThrow(), targetPath);
-            logger.info("Exported to " + bundle);
+            Path targetDirectory = Config.getCanonicalPath(Path.of(directory).toAbsolutePath());
+            if (Files.exists(targetDirectory)) {
+                throw new MojoExecutionException("Exporting to existing directory not supported");
+            }
+            Path result;
+            logger.info("Writing store {} as directory to {}", store, directory);
+            try (ArtifactStoreWriter artifactStoreWriter = ns.createArtifactStoreWriter()) {
+                result = artifactStoreWriter.writeAsDirectory(storeOptional.orElseThrow(), targetDirectory);
+            }
+            logger.info("Written to " + result);
         } else {
             logger.warn("ArtifactStore with given name not found");
         }

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.github.mizosoft.methanol</groupId>
+        <artifactId>methanol</artifactId>
+        <version>1.8.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
         <version>5.12.2</version>

--- a/publisher/sonatype/pom.xml
+++ b/publisher/sonatype/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>com.github.mizosoft.methanol</groupId>
       <artifactId>methanol</artifactId>
-      <version>1.8.2</version>
     </dependency>
 
     <dependency>

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -16,12 +16,12 @@ import com.github.mizosoft.methanol.MutableRequest;
 import eu.maveniverse.maven.njord.shared.Config;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.impl.FileUtils;
-import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreExporterFactory;
+import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreWriterFactory;
 import eu.maveniverse.maven.njord.shared.impl.publisher.ArtifactStorePublisherSupport;
 import eu.maveniverse.maven.njord.shared.impl.repository.ArtifactStoreDeployer;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreExporter;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +33,7 @@ import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.RemoteRepository;
 
 public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSupport {
-    private final ArtifactStoreExporterFactory artifactStoreExporterFactory;
+    private final ArtifactStoreWriterFactory artifactStoreWriterFactory;
 
     public SonatypeCentralPortalPublisher(
             SessionConfig sessionConfig,
@@ -41,7 +41,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
             RemoteRepository releasesRepository,
             RemoteRepository snapshotsRepository,
             ArtifactStoreRequirements artifactStoreRequirements,
-            ArtifactStoreExporterFactory artifactStoreExporterFactory) {
+            ArtifactStoreWriterFactory artifactStoreWriterFactory) {
         super(
                 sessionConfig,
                 repositorySystem,
@@ -52,7 +52,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 releasesRepository,
                 snapshotsRepository,
                 artifactStoreRequirements);
-        this.artifactStoreExporterFactory = requireNonNull(artifactStoreExporterFactory);
+        this.artifactStoreWriterFactory = requireNonNull(artifactStoreWriterFactory);
     }
 
     @Override
@@ -63,8 +63,8 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
             Path tmpDir = Files.createTempDirectory(name);
             try {
                 Path bundle;
-                try (ArtifactStoreExporter artifactStoreExporter = artifactStoreExporterFactory.create(sessionConfig)) {
-                    bundle = artifactStoreExporter.exportAsBundle(artifactStore, tmpDir);
+                try (ArtifactStoreWriter artifactStoreWriter = artifactStoreWriterFactory.create(sessionConfig)) {
+                    bundle = artifactStoreWriter.writeAsBundle(artifactStore, tmpDir);
                 }
                 if (bundle == null) {
                     throw new IllegalStateException("Bundle ZIP was not created");

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherFactory.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherFactory.java
@@ -10,7 +10,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
-import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreExporterFactory;
+import eu.maveniverse.maven.njord.shared.impl.factories.ArtifactStoreWriterFactory;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherFactory;
 import javax.inject.Inject;
@@ -25,16 +25,16 @@ public class SonatypeCentralPortalPublisherFactory implements ArtifactStorePubli
     public static final String NAME = "sonatype-cp";
 
     private final RepositorySystem repositorySystem;
-    private final ArtifactStoreExporterFactory artifactStoreExporterFactory;
+    private final ArtifactStoreWriterFactory artifactStoreWriterFactory;
     private final SonatypeCentralRequirementsFactory centralRequirementsFactory;
 
     @Inject
     public SonatypeCentralPortalPublisherFactory(
             RepositorySystem repositorySystem,
-            ArtifactStoreExporterFactory artifactStoreExporterFactory,
+            ArtifactStoreWriterFactory artifactStoreWriterFactory,
             SonatypeCentralRequirementsFactory centralRequirementsFactory) {
         this.repositorySystem = requireNonNull(repositorySystem);
-        this.artifactStoreExporterFactory = requireNonNull(artifactStoreExporterFactory);
+        this.artifactStoreWriterFactory = requireNonNull(artifactStoreWriterFactory);
         this.centralRequirementsFactory = requireNonNull(centralRequirementsFactory);
     }
 
@@ -55,6 +55,6 @@ public class SonatypeCentralPortalPublisherFactory implements ArtifactStorePubli
                 releasesRepository,
                 snapshotsRepository,
                 centralRequirementsFactory.create(sessionConfig),
-                artifactStoreExporterFactory);
+                artifactStoreWriterFactory);
     }
 }


### PR DESCRIPTION
Rename two existing Mojos from `export` and `export-bundle` to `write` and `write-bundle` as they are not really exporting but just writing out.

Implement `export` and `import` Mojos and internals. Now a store can be transferred from one WS to another WS.