### PR TITLE
Lax pom validation

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
@@ -75,7 +75,7 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                     for (License license : m.getLicenses()) {
                         if (ok && (nullOrBlank(license.getName()) || nullOrBlank(license.getUrl()))) {
                             ok = false;
-                            collector.addError("MISSING (incomplete) project/licenses/license (name, url)");
+                            collector.addError("MISSING project/licenses/license (name, url)");
                         }
                     }
                     if (ok) {
@@ -90,7 +90,7 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                         if (ok && (nullOrBlank(developer.getId()) && nullOrBlank(developer.getName()) && nullOrBlank(developer.getEmail()))) {
                             ok = false;
                             collector.addError(
-                                    "MISSING (incomplete) project/developers/developer (id, name or email)");
+                                    "MISSING project/developers/developer (id, name or email)");
                         }
                         if (ok && nullOrBlank(developer.getId()) || nullOrBlank(developer.getName()) || nullOrBlank(developer.getEmail())) {
                             collector.addWarning("INCOMPLETE project/developers/developer (id, name or email)");
@@ -107,7 +107,7 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                     if (nullOrBlank(scm.getUrl())
                             || nullOrBlank(scm.getConnection())
                             || nullOrBlank(scm.getDeveloperConnection())) {
-                        collector.addError("MISSING (incomplete) project/scm (url, connection, developerConnection)");
+                        collector.addError("MISSING project/scm (url, connection, developerConnection)");
                     }
                 }
             } else {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
@@ -73,7 +73,7 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                 } else {
                     boolean ok = true;
                     for (License license : m.getLicenses()) {
-                        if (nullOrBlank(license.getName()) || nullOrBlank(license.getUrl())) {
+                        if (ok && (nullOrBlank(license.getName()) || nullOrBlank(license.getUrl()))) {
                             ok = false;
                             collector.addError("MISSING (incomplete) project/licenses/license (name, url)");
                         }
@@ -87,10 +87,13 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                 } else {
                     boolean ok = true;
                     for (Developer developer : m.getDevelopers()) {
-                        if (nullOrBlank(developer.getId()) || nullOrBlank(developer.getName())) {
+                        if (ok && (nullOrBlank(developer.getId()) && nullOrBlank(developer.getName()) && nullOrBlank(developer.getEmail()))) {
                             ok = false;
                             collector.addError(
-                                    "MISSING (incomplete) project/developers/developer (id, name)");
+                                    "MISSING (incomplete) project/developers/developer (id, name or email)");
+                        }
+                        if (ok && nullOrBlank(developer.getId()) || nullOrBlank(developer.getName()) || nullOrBlank(developer.getEmail())) {
+                            collector.addWarning("INCOMPLETE project/developers/developer (id, name or email)");
                         }
                     }
                     if (ok) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
@@ -53,17 +53,17 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
             Optional<Model> mo = modelProvider.readEffectiveModel(session, artifact, remoteRepositories);
             if (mo.isPresent()) {
                 Model m = mo.orElseThrow();
-                if (m.getName() != null && !m.getName().trim().isEmpty()) {
+                if (!nullOrBlank(m.getName())) {
                     collector.addInfo("VALID project/name");
                 } else {
                     collector.addError("MISSING project/name");
                 }
-                if (m.getDescription() != null && !m.getDescription().trim().isEmpty()) {
+                if (!nullOrBlank(m.getDescription())) {
                     collector.addInfo("VALID project/description");
                 } else {
                     collector.addError("MISSING project/description");
                 }
-                if (m.getUrl() != null && !m.getUrl().trim().isEmpty()) {
+                if (!nullOrBlank(m.getUrl())) {
                     collector.addInfo("VALID project/url");
                 } else {
                     collector.addError("MISSING project/url");
@@ -73,12 +73,9 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                 } else {
                     boolean ok = true;
                     for (License license : m.getLicenses()) {
-                        if ((license.getName() == null
-                                        || license.getName().trim().isEmpty())
-                                || (license.getUrl() == null
-                                        || license.getUrl().trim().isEmpty())) {
+                        if (nullOrBlank(license.getName()) || nullOrBlank(license.getUrl())) {
                             ok = false;
-                            collector.addError("MISSING (incomplete) project/licenses/license");
+                            collector.addError("MISSING (incomplete) project/licenses/license (name, url)");
                         }
                     }
                     if (ok) {
@@ -90,33 +87,33 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                 } else {
                     boolean ok = true;
                     for (Developer developer : m.getDevelopers()) {
-                        if ((developer.getName() == null
-                                        || developer.getName().trim().isEmpty())
-                                || (developer.getEmail() == null
-                                        || developer.getEmail().trim().isEmpty())) {
+                        if (nullOrBlank(developer.getId()) || nullOrBlank(developer.getName())) {
                             ok = false;
-                            collector.addError("MISSING (incomplete) project/developers/developer");
+                            collector.addError(
+                                    "MISSING (incomplete) project/developers/developer (id, name)");
                         }
                     }
                     if (ok) {
-                        collector.addInfo("VALID project/licenses");
+                        collector.addInfo("VALID project/developers");
                     }
                 }
                 if (m.getScm() == null) {
                     collector.addError("MISSING project/scm");
                 } else {
                     Scm scm = m.getScm();
-                    if ((scm.getUrl() == null || scm.getUrl().trim().isEmpty())
-                            || (scm.getConnection() == null
-                                    || scm.getConnection().trim().isEmpty())
-                            || (scm.getDeveloperConnection() == null
-                                    || scm.getDeveloperConnection().trim().isEmpty())) {
-                        collector.addError("MISSING (incomplete) project/scm");
+                    if (nullOrBlank(scm.getUrl())
+                            || nullOrBlank(scm.getConnection())
+                            || nullOrBlank(scm.getDeveloperConnection())) {
+                        collector.addError("MISSING (incomplete) project/scm (url, connection, developerConnection)");
                     }
                 }
             } else {
                 collector.addWarning("Could not get effective model");
             }
         }
+    }
+
+    private boolean nullOrBlank(String str) {
+        return str == null || str.trim().isEmpty();
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
@@ -87,12 +87,16 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
                 } else {
                     boolean ok = true;
                     for (Developer developer : m.getDevelopers()) {
-                        if (ok && (nullOrBlank(developer.getId()) && nullOrBlank(developer.getName()) && nullOrBlank(developer.getEmail()))) {
+                        if (ok
+                                && (nullOrBlank(developer.getId())
+                                        && nullOrBlank(developer.getName())
+                                        && nullOrBlank(developer.getEmail()))) {
                             ok = false;
-                            collector.addError(
-                                    "MISSING project/developers/developer (id, name or email)");
+                            collector.addError("MISSING project/developers/developer (id, name or email)");
                         }
-                        if (ok && nullOrBlank(developer.getId()) || nullOrBlank(developer.getName()) || nullOrBlank(developer.getEmail())) {
+                        if (ok && nullOrBlank(developer.getId())
+                                || nullOrBlank(developer.getName())
+                                || nullOrBlank(developer.getEmail())) {
                             collector.addWarning("INCOMPLETE project/developers/developer (id, name or email)");
                         }
                     }


### PR DESCRIPTION
Changes:
* lax POM project/developers/developer validation: require one of `id`, `name` or `email`