### PR TITLE
Publish and Validate mojo improvements

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/Config.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/Config.java
@@ -30,6 +30,10 @@ public interface Config {
     RemoteRepository CENTRAL =
             new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build();
 
+    String NJORD_PREFIX = "njord.prefix";
+
+    String NJORD_TARGET = "njord.target";
+
     boolean enabled();
 
     Optional<String> version();

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/Config.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/Config.java
@@ -30,6 +30,10 @@ public interface Config {
     RemoteRepository CENTRAL =
             new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build();
 
+    String NJORD_AUTOPREFIX = "njord.autoprefix";
+
+    String DEFAULT_NJORD_AUTOPREFIX = Boolean.TRUE.toString();
+
     String NJORD_PREFIX = "njord.prefix";
 
     String NJORD_TARGET = "njord.target";

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -7,9 +7,12 @@
  */
 package eu.maveniverse.maven.njord.shared;
 
+import static eu.maveniverse.maven.njord.shared.Config.NJORD_PREFIX;
+import static eu.maveniverse.maven.njord.shared.Config.NJORD_TARGET;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 
@@ -31,6 +34,16 @@ public interface SessionConfig {
      * Njord config, never {@code null}.
      */
     Config config();
+
+    /**
+     * The prefix to override template prefix, if needed.
+     */
+    Optional<String> prefix();
+
+    /**
+     * The target, to use if specified.
+     */
+    Optional<String> target();
 
     /**
      * Returns this instance as builder.
@@ -92,6 +105,16 @@ public interface SessionConfig {
             @Override
             public Config config() {
                 return config;
+            }
+
+            @Override
+            public Optional<String> prefix() {
+                return Optional.ofNullable(config().effectiveProperties().get(NJORD_PREFIX));
+            }
+
+            @Override
+            public Optional<String> target() {
+                return Optional.ofNullable(config().effectiveProperties().get(NJORD_TARGET));
             }
 
             @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSession.java
@@ -7,7 +7,6 @@
  */
 package eu.maveniverse.maven.njord.shared.impl;
 
-import static eu.maveniverse.maven.njord.shared.Config.NJORD_PREFIX;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.NjordSession;
@@ -106,9 +105,8 @@ public class DefaultNjordSession extends CloseableConfigSupport<SessionConfig> i
                     if (uri.isEmpty()) {
                         // empty -> default
                         ArtifactStoreTemplate template = internalArtifactStoreManager.defaultTemplate();
-                        if (config.config().effectiveProperties().containsKey(NJORD_PREFIX)) {
-                            template = template.withPrefix(
-                                    config.config().effectiveProperties().get(NJORD_PREFIX));
+                        if (config.prefix().isPresent()) {
+                            template = template.withPrefix(config.prefix().orElseThrow());
                         }
                         try (ArtifactStore artifactStore = internalArtifactStoreManager.createArtifactStore(template)) {
                             artifactStoreName = artifactStore.name();
@@ -122,9 +120,8 @@ public class DefaultNjordSession extends CloseableConfigSupport<SessionConfig> i
                             throw new IllegalArgumentException("Unknown template: " + uri);
                         } else {
                             ArtifactStoreTemplate template = templates.get(0);
-                            if (config.config().effectiveProperties().containsKey(NJORD_PREFIX)) {
-                                template = template.withPrefix(
-                                        config.config().effectiveProperties().get(NJORD_PREFIX));
+                            if (config.prefix().isPresent()) {
+                                template = template.withPrefix(config.prefix().orElseThrow());
                             }
                             try (ArtifactStore artifactStore =
                                     internalArtifactStoreManager.createArtifactStore(template)) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultNjordSession.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.njord.shared.impl;
 
+import static eu.maveniverse.maven.njord.shared.Config.NJORD_PREFIX;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.NjordSession;
@@ -104,8 +105,12 @@ public class DefaultNjordSession extends CloseableConfigSupport<SessionConfig> i
                 if (!uri.contains(":")) {
                     if (uri.isEmpty()) {
                         // empty -> default
-                        try (ArtifactStore artifactStore = internalArtifactStoreManager.createArtifactStore(
-                                internalArtifactStoreManager.defaultTemplate())) {
+                        ArtifactStoreTemplate template = internalArtifactStoreManager.defaultTemplate();
+                        if (config.config().effectiveProperties().containsKey(NJORD_PREFIX)) {
+                            template = template.withPrefix(
+                                    config.config().effectiveProperties().get(NJORD_PREFIX));
+                        }
+                        try (ArtifactStore artifactStore = internalArtifactStoreManager.createArtifactStore(template)) {
                             artifactStoreName = artifactStore.name();
                         }
                     } else {
@@ -116,8 +121,13 @@ public class DefaultNjordSession extends CloseableConfigSupport<SessionConfig> i
                         if (templates.size() != 1) {
                             throw new IllegalArgumentException("Unknown template: " + uri);
                         } else {
+                            ArtifactStoreTemplate template = templates.get(0);
+                            if (config.config().effectiveProperties().containsKey(NJORD_PREFIX)) {
+                                template = template.withPrefix(
+                                        config.config().effectiveProperties().get(NJORD_PREFIX));
+                            }
                             try (ArtifactStore artifactStore =
-                                    internalArtifactStoreManager.createArtifactStore(templates.get(0))) {
+                                    internalArtifactStoreManager.createArtifactStore(template)) {
                                 artifactStoreName = artifactStore.name();
                             }
                         }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStore.java
@@ -276,11 +276,16 @@ public class DefaultArtifactStore extends CloseableSupport implements ArtifactSt
     public String toString() {
         if (closed.get()) {
             return String.format(
-                    "%s (%s, %s, closed)", name(), created(), repositoryMode().name());
+                    "%s (%s, %s, %s, closed)",
+                    name(), created(), repositoryMode().name(), template.name());
         } else {
             return String.format(
-                    "%s (%s, %s, %s artifacts)",
-                    name(), created(), repositoryMode().name(), artifacts().size());
+                    "%s (%s, %s, %s, %s artifacts)",
+                    name(),
+                    created(),
+                    repositoryMode().name(),
+                    template.name(),
+                    artifacts().size());
         }
     }
 

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
@@ -10,13 +10,21 @@ package eu.maveniverse.maven.njord.shared.store;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ArtifactStoreManager {
     /**
      * Lists store "probable names". Not all element name may be a store, check with {@link #selectArtifactStore(String)}.
+     * The result is ordered in natural order (growing).
      */
-    Collection<String> listArtifactStoreNames() throws IOException;
+    List<String> listArtifactStoreNames() throws IOException;
+
+    /**
+     * Lists store "probable names" for given prefix. Not all element name may be a store, check with {@link #selectArtifactStore(String)}.
+     * The result is ordered in natural order (growing).
+     */
+    List<String> listArtifactStoreNamesForPrefix(String prefix) throws IOException;
 
     /**
      * Selects artifact store. If selected (optional is not empty), caller must close it.

--- a/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordLifecycleParticipant.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.njord.extension3;
 
+import static eu.maveniverse.maven.njord.shared.Config.DEFAULT_NJORD_AUTOPREFIX;
+import static eu.maveniverse.maven.njord.shared.Config.NJORD_AUTOPREFIX;
 import static eu.maveniverse.maven.njord.shared.Config.NJORD_PREFIX;
 import static eu.maveniverse.maven.njord.shared.Config.NJORD_TARGET;
 import static java.util.Objects.requireNonNull;
@@ -56,11 +58,15 @@ public class NjordLifecycleParticipant extends AbstractMavenLifecycleParticipant
                     && !"org.apache.maven:standalone-pom"
                             .equals(currentProject.getGroupId() + ":" + currentProject.getArtifactId())) {
                 if (!userProperties.containsKey(NJORD_PREFIX) && !systemProperties.containsKey(NJORD_PREFIX)) {
+                    boolean autoPrefix = Boolean.parseBoolean(
+                            userProperties.getOrDefault(NJORD_AUTOPREFIX, DEFAULT_NJORD_AUTOPREFIX));
                     String prefix = currentProject.getProperties().getProperty(NJORD_PREFIX);
-                    if (prefix == null) {
+                    if (autoPrefix && prefix == null) {
                         prefix = currentProject.getArtifactId();
                     }
-                    userProperties.put(NJORD_PREFIX, prefix);
+                    if (prefix != null) {
+                        userProperties.put(NJORD_PREFIX, prefix);
+                    }
                 }
                 if (!userProperties.containsKey(NJORD_TARGET) && !systemProperties.containsKey(NJORD_TARGET)) {
                     String target = currentProject.getProperties().getProperty(NJORD_TARGET);

--- a/it/extension-its/src/it/basic-prefix/.mvn/extensions.xml
+++ b/it/extension-its/src/it/basic-prefix/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/basic-prefix/README.md
+++ b/it/extension-its/src/it/basic-prefix/README.md
@@ -1,0 +1,3 @@
+# Basic
+
+Tests basic usage of Njord.

--- a/it/extension-its/src/it/basic-prefix/invoker.properties
+++ b/it/extension-its/src/it/basic-prefix/invoker.properties
@@ -9,10 +9,10 @@
 # 0th: clean
 invoker.goals.1 = -V -e njord:${project.version}:drop-all -Dyes
 # 1st: deploy/stage to release
-invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-sca -l first.log
+invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release -l first.log
 # 2nd: deploy/stage to release-sca
-invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-redeploy-sca -l second.log -Dattach-classifier=second
-# 3rd: redeploy
-invoker.goals.4 = -V -e njord:${project.version}:redeploy -Dfrom=redeploy-release-00001 -Dto=redeploy-release-00002 -Ddrop -l third.log
+invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-sca -l second.log
+# 3rd: deploy/stage to release-redeploy-sca
+invoker.goals.4 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-redeploy-sca -l third.log
 # 4th: list
 invoker.goals.5 = -V -e njord:${project.version}:list -l fourth.log

--- a/it/extension-its/src/it/basic-prefix/pom.xml
+++ b/it/extension-its/src/it/basic-prefix/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>eu.maveniverse.maven.njord.it</groupId>
-    <artifactId>merge-all-release</artifactId>
+    <artifactId>basic-prefix</artifactId>
     <version>1.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -20,10 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <!-- Build MUST BE reproducible -->
-        <project.build.outputTimestamp>2025-04-17T00:00:00Z</project.build.outputTimestamp>
-        <attach-classifier>first</attach-classifier>
+        <njord.prefix>something-else</njord.prefix>
     </properties>
 
     <dependencies>
@@ -40,32 +37,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.6.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-fake</id>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>target/merge-all-release-1.0.0.jar</file>
-                                    <type>jar</type>
-                                    <classifier>${attach-classifier}</classifier>
-                                </artifact>
-                            </artifacts>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/it/extension-its/src/it/basic-prefix/verify.groovy
+++ b/it/extension-its/src/it/basic-prefix/verify.groovy
@@ -26,17 +26,19 @@ var fourth = fourthLog.text
 
 // first run:
 assert first.contains("[INFO] Njord ${projectVersion} session created")
-assert first.contains('[INFO] Using alternate deployment repository id::njord:release-sca')
+assert first.contains('[INFO] Using alternate deployment repository id::njord:release')
 
 // second run:
 assert second.contains("[INFO] Njord ${projectVersion} session created")
-assert second.contains('[INFO] Using alternate deployment repository id::njord:release-redeploy-sca')
+assert second.contains('[INFO] Using alternate deployment repository id::njord:release-sca')
 
 // third run:
 assert third.contains("[INFO] Njord ${projectVersion} session created")
-assert third.contains('[INFO] Redeploying redeploy-release-00001')
-assert third.contains('[INFO] Dropping redeploy-release-00001')
+assert third.contains('[INFO] Using alternate deployment repository id::njord:release-redeploy-sca')
 
 // fourth run:
 assert fourth.contains("[INFO] Njord ${projectVersion} session created")
-assert fourth.contains('[INFO] Total of 1 ArtifactStore.')
+assert fourth.contains('[INFO] - something-else-00001')
+assert fourth.contains('[INFO] - something-else-00002')
+assert fourth.contains('[INFO] - something-else-00003')
+assert fourth.contains('[INFO] Total of 3 ArtifactStore.')

--- a/it/extension-its/src/it/compare/invoker.properties
+++ b/it/extension-its/src/it/compare/invoker.properties
@@ -13,4 +13,4 @@ invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release
 # 2nd: deploy/stage to release
 invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release -l second.log
 # 3rd: compare
-invoker.goals.4 = -V -e njord:${project.version}:compare -Dstore1=release-00001 -Dstore2=release-00002 -Ddetails -l third.log
+invoker.goals.4 = -V -e njord:${project.version}:compare -Dstore1=compare-00001 -Dstore2=compare-00002 -Ddetails -l third.log

--- a/it/extension-its/src/it/compare/pom.xml
+++ b/it/extension-its/src/it/compare/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>eu.maveniverse.maven.njord.it</groupId>
-    <artifactId>basic</artifactId>
+    <artifactId>compare</artifactId>
     <version>1.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/it/extension-its/src/it/compare/verify.groovy
+++ b/it/extension-its/src/it/compare/verify.groovy
@@ -30,4 +30,4 @@ assert second.contains('[INFO] Using alternate deployment repository id::njord:r
 
 // third run:
 assert third.contains("[INFO] Njord ${projectVersion} session created")
-assert third.contains('[INFO] ArtifactStore release-00001 and release-00002 are EQUAL')
+assert third.contains('[INFO] ArtifactStore compare-00001 and compare-00002 are EQUAL')

--- a/it/extension-its/src/it/export-import/invoker.properties
+++ b/it/extension-its/src/it/export-import/invoker.properties
@@ -11,8 +11,8 @@ invoker.goals.1 = -V -e njord:${project.version}:drop-all -Dyes
 # 1st: deploy/stage to release
 invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-sca -l first.log
 # 2nd: export
-invoker.goals.3 = -V -e njord:${project.version}:export -Dstore=release-sca-00001 -l second.log
+invoker.goals.3 = -V -e njord:${project.version}:export -Dstore=export-import-00001 -l second.log
 # 3rd: import
-invoker.goals.4 = -V -e njord:${project.version}:import -Dfile=release-sca-00001.ntb -l third.log
+invoker.goals.4 = -V -e njord:${project.version}:import -Dfile=export-import-00001.ntb -l third.log
 # 4th: list
 invoker.goals.5 = -V -e njord:${project.version}:list -l fourth.log

--- a/it/extension-its/src/it/export-import/pom.xml
+++ b/it/extension-its/src/it/export-import/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>eu.maveniverse.maven.njord.it</groupId>
-    <artifactId>merge-release</artifactId>
+    <artifactId>export-import</artifactId>
     <version>1.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -57,7 +57,7 @@
                         <configuration>
                             <artifacts>
                                 <artifact>
-                                    <file>target/merge-release-1.0.0.jar</file>
+                                    <file>target/export-import-1.0.0.jar</file>
                                     <type>jar</type>
                                     <classifier>${attach-classifier}</classifier>
                                 </artifact>

--- a/it/extension-its/src/it/export-import/verify.groovy
+++ b/it/extension-its/src/it/export-import/verify.groovy
@@ -30,7 +30,7 @@ assert first.contains('[INFO] Using alternate deployment repository id::njord:re
 
 // second run:
 assert second.contains("[INFO] Njord ${projectVersion} session created")
-assert second.contains('[INFO] Exporting store release-sca-00001 to')
+assert second.contains('[INFO] Exporting store export-import-00001 to')
 assert second.contains('[INFO] Exported to ')
 
 // third run:

--- a/it/extension-its/src/it/merge-all-release/invoker.properties
+++ b/it/extension-its/src/it/merge-all-release/invoker.properties
@@ -13,9 +13,9 @@ invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release
 # 2nd: deploy/stage
 invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-sca -l l02.log -Dattach-classifier=second
 # 3rd: export first
-invoker.goals.4 = -V -e njord:${project.version}:export -Dstore=release-sca-00001 -l l03.log
+invoker.goals.4 = -V -e njord:${project.version}:export -Dstore=merge-all-release-00001 -l l03.log
 # 4th: export second
-invoker.goals.5 = -V -e njord:${project.version}:export -Dstore=release-sca-00002 -l l04.log
+invoker.goals.5 = -V -e njord:${project.version}:export -Dstore=merge-all-release-00002 -l l04.log
 # 5th: tabula rasa
 invoker.goals.6 = -V -e njord:${project.version}:drop-all -Dyes -l l05.log
 # 6th: import-all

--- a/it/extension-its/src/it/merge-all-release/verify.groovy
+++ b/it/extension-its/src/it/merge-all-release/verify.groovy
@@ -50,11 +50,11 @@ assert second.contains('[INFO] Using alternate deployment repository id::njord:r
 
 // third run:
 assert third.contains("[INFO] Njord ${projectVersion} session created")
-assert third.contains('[INFO] Exporting store release-sca-00001')
+assert third.contains('[INFO] Exporting store merge-all-release-00001')
 
 // fourth run:
 assert fourth.contains("[INFO] Njord ${projectVersion} session created")
-assert fourth.contains('[INFO] Exporting store release-sca-00002')
+assert fourth.contains('[INFO] Exporting store merge-all-release-00002')
 
 // fifth run:
 assert fifth.contains("[INFO] Njord ${projectVersion} session created")
@@ -66,8 +66,8 @@ assert sixth.contains('[INFO] Importing stores from')
 
 // seventh run:
 assert seventh.contains("[INFO] Njord ${projectVersion} session created")
-assert seventh.contains('[INFO] Merging release-sca-00001')
-assert seventh.contains('[INFO] Merging release-sca-00002')
+assert seventh.contains('[INFO] Merging merge-all-release-00001')
+assert seventh.contains('[INFO] Merging merge-all-release-00002')
 
 // eighth run:
 assert eighth.contains("[INFO] Njord ${projectVersion} session created")

--- a/it/extension-its/src/it/merge-release/invoker.properties
+++ b/it/extension-its/src/it/merge-release/invoker.properties
@@ -13,6 +13,6 @@ invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release
 # 2nd: deploy/stage to release-sca
 invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release-sca -l second.log -Dattach-classifier=second
 # 3rd: merge
-invoker.goals.4 = -V -e njord:${project.version}:merge -Dfrom=release-sca-00001 -Dto=release-sca-00002 -Ddrop -l third.log
+invoker.goals.4 = -V -e njord:${project.version}:merge -Dfrom=merge-release-00001 -Dto=merge-release-00002 -Ddrop -l third.log
 # 4th: list
 invoker.goals.5 = -V -e njord:${project.version}:list -l fourth.log

--- a/it/extension-its/src/it/merge-release/verify.groovy
+++ b/it/extension-its/src/it/merge-release/verify.groovy
@@ -34,8 +34,8 @@ assert second.contains('[INFO] Using alternate deployment repository id::njord:r
 
 // third run:
 assert third.contains("[INFO] Njord ${projectVersion} session created")
-assert third.contains('[INFO] Merging release-sca-00001')
-assert third.contains('[INFO] Dropping release-sca-00001')
+assert third.contains('[INFO] Merging merge-release-00001')
+assert third.contains('[INFO] Dropping merge-release-00001')
 
 // fourth run:
 assert fourth.contains("[INFO] Njord ${projectVersion} session created")

--- a/it/extension-its/src/it/redeploy-snapshot/invoker.properties
+++ b/it/extension-its/src/it/redeploy-snapshot/invoker.properties
@@ -13,6 +13,6 @@ invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:snapsho
 # 2nd: deploy/stage to release-sca
 invoker.goals.3 = -V -e clean deploy -DaltDeploymentRepository=id::njord:snapshot-sca -l second.log -Dattach-classifier=second
 # 3rd: redeploy
-invoker.goals.4 = -V -e njord:${project.version}:redeploy -Dfrom=snapshot-sca-00001 -Dto=snapshot-sca-00002 -Ddrop -l third.log
+invoker.goals.4 = -V -e njord:${project.version}:redeploy -Dfrom=redeploy-snapshot-00001 -Dto=redeploy-snapshot-00002 -Ddrop -l third.log
 # 4th: list
 invoker.goals.5 = -V -e njord:${project.version}:list -l fourth.log

--- a/it/extension-its/src/it/redeploy-snapshot/verify.groovy
+++ b/it/extension-its/src/it/redeploy-snapshot/verify.groovy
@@ -34,8 +34,8 @@ assert second.contains('[INFO] Using alternate deployment repository id::njord:s
 
 // third run:
 assert third.contains("[INFO] Njord ${projectVersion} session created")
-assert third.contains('[INFO] Redeploying snapshot-sca-00001')
-assert third.contains('[INFO] Dropping snapshot-sca-00001')
+assert third.contains('[INFO] Redeploying redeploy-snapshot-00001')
+assert third.contains('[INFO] Dropping redeploy-snapshot-00001')
 
 // fourth run:
 assert fourth.contains("[INFO] Njord ${projectVersion} session created")

--- a/it/extension-its/src/it/validate/.mvn/extensions.xml
+++ b/it/extension-its/src/it/validate/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/validate/.mvn/maven.config
+++ b/it/extension-its/src/it/validate/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dnjord.target=sonatype-cp

--- a/it/extension-its/src/it/validate/README.md
+++ b/it/extension-its/src/it/validate/README.md
@@ -1,0 +1,11 @@
+# Validate
+
+Tests validate of Njord.
+
+The point is that the two mandatory parameters for `validate` mojo are populated, so caller is not 
+specifying them:
+* `target` is set in `.mvn/maven.config` to `sonatype-cp`.
+* `store` is automatically discovered (prefix is set, and there is only one store with this prefix).
+
+Outcome is build failure, as Central validation will fail since staged store does not contains
+signatures, javadoc and sources.

--- a/it/extension-its/src/it/validate/invoker.properties
+++ b/it/extension-its/src/it/validate/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# 0th: clean
+invoker.goals.1 = -V -e njord:${project.version}:drop-all -Dyes
+# 1st: deploy/stage to release
+invoker.goals.2 = -V -e clean deploy -DaltDeploymentRepository=id::njord:release -l first.log
+# 2nd: validate
+invoker.goals.3 = -V -e njord:${project.version}:validate -l second.log
+# validation should fail (no GPG, javadoc, sources...)
+invoker.buildResult.3 = failure

--- a/it/extension-its/src/it/validate/pom.xml
+++ b/it/extension-its/src/it/validate/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.njord.it</groupId>
+    <artifactId>validate</artifactId>
+    <version>1.0.0</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.outputTimestamp>2025-04-29T00:00:00Z</project.build.outputTimestamp>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension-its/src/it/validate/verify.groovy
+++ b/it/extension-its/src/it/validate/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File firstLog = new File( basedir, 'first.log' )
+assert firstLog.exists()
+var first = firstLog.text
+
+File secondLog = new File( basedir, 'second.log' )
+assert secondLog.exists()
+var second = secondLog.text
+
+// Lets make strict assertion
+// Also, consider Maven 3 vs 4 diff: they resolve differently; do not assert counts
+
+// first run:
+assert first.contains("[INFO] Njord ${projectVersion} session created")
+assert first.contains('[INFO] Using alternate deployment repository id::njord:release')
+
+// second run:
+assert second.contains("[INFO] Njord ${projectVersion} session created")
+assert second.contains('[ERROR] ArtifactStore validate-00001')
+assert second.contains(' failed validation')

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListMojo.java
@@ -10,7 +10,7 @@ package eu.maveniverse.maven.njord.plugin3;
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -22,7 +22,7 @@ public class ListMojo extends NjordMojoSupport {
     @Override
     protected void doExecute(NjordSession ns) throws IOException {
         logger.info("List of existing ArtifactStore:");
-        Collection<String> storeNames = ns.artifactStoreManager().listArtifactStoreNames();
+        List<String> storeNames = ns.artifactStoreManager().listArtifactStoreNames();
         for (String storeName : storeNames) {
             Optional<ArtifactStore> aso = ns.artifactStoreManager().selectArtifactStore(storeName);
             if (aso.isPresent()) {

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListTemplatesMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListTemplatesMojo.java
@@ -25,7 +25,7 @@ public class ListTemplatesMojo extends NjordMojoSupport {
         ArtifactStoreTemplate defaultTemplate = ns.artifactStoreManager().defaultTemplate();
         for (ArtifactStoreTemplate template : templates) {
             logger.info("- {} {}", template.name(), template == defaultTemplate ? " (default)" : " ");
-            logger.info("    Prefix: {}", template.prefix());
+            logger.info("    Default prefix: '{}'", template.prefix());
             logger.info("    Repository Mode: {}", template.repositoryMode());
             logger.info("    Allow redeploy: {}", template.allowRedeploy());
             logger.info(

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/MergeAllMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/MergeAllMojo.java
@@ -45,7 +45,7 @@ public class MergeAllMojo extends NjordMojoSupport {
                 try (ArtifactStore store = so.orElseThrow()) {
                     if (template == null) {
                         template = store.template();
-                    } else if (template != store.template()) {
+                    } else if (!template.equals(store.template())) {
                         throw new MojoExecutionException("Conflicting templates used");
                     }
                 }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublishMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublishMojo.java
@@ -24,13 +24,13 @@ public class PublishMojo extends NjordMojoSupport {
     /**
      * The name of the store to publish.
      */
-    @Parameter(required = true, property = "store")
+    @Parameter(required = true, property = "store", alias = "njord.publish.store")
     private String store;
 
     /**
      * The name of the publisher to publish to.
      */
-    @Parameter(required = true, property = "target")
+    @Parameter(required = true, property = "target", alias = "njord.publish.target")
     private String target;
 
     /**

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublishMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublishMojo.java
@@ -22,7 +22,7 @@ public class PublishMojo extends PublisherSupportMojo {
     /**
      * Whether source store should be dropped after successful operation.
      */
-    @Parameter(required = true, property = "drop", defaultValue = "false")
+    @Parameter(required = true, property = "drop", defaultValue = "true")
     private boolean drop;
 
     @Override

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
@@ -7,10 +7,13 @@
  */
 package eu.maveniverse.maven.njord.plugin3;
 
+import static eu.maveniverse.maven.njord.shared.Config.NJORD_PREFIX;
+
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -22,16 +25,39 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
     /**
      * The name of the store to publish.
      */
-    @Parameter(required = true, property = "store")
+    @Parameter(property = "store")
     protected String store;
 
     /**
      * The name of the publisher to publish to.
      */
-    @Parameter(required = true, property = "target")
+    @Parameter(required = true, property = "target", defaultValue = "${njord.target}")
     protected String target;
 
     protected ArtifactStore getArtifactStore(NjordSession ns) throws IOException, MojoFailureException {
+        if (store == null) {
+            logger.info("No store name specified, using heuristic to find store");
+            if (ns.sessionConfig().config().effectiveProperties().containsKey(NJORD_PREFIX)) {
+                String prefix =
+                        ns.sessionConfig().config().effectiveProperties().get(NJORD_PREFIX);
+                if (prefix != null) {
+                    List<String> storeNames = ns.artifactStoreManager().listArtifactStoreNamesForPrefix(prefix);
+                    if (!storeNames.isEmpty()) {
+                        if (storeNames.size() == 1) {
+                            store = storeNames.get(0);
+                            logger.info("Found one store, using it: '{}'", store);
+                        } else {
+                            store = storeNames.get(storeNames.size() - 1);
+                            logger.info("Found multiple stores, using latest: '{}'", store);
+                        }
+                    }
+                }
+            }
+        }
+        if (store == null) {
+            throw new MojoFailureException("ArtifactStore name was not specified nor could be found");
+        }
+
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
         if (storeOptional.isEmpty()) {
             logger.warn("ArtifactStore with given name not found: {}", store);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.njord.plugin3;
+
+import eu.maveniverse.maven.njord.shared.NjordSession;
+import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Publisher support mojo.
+ */
+public abstract class PublisherSupportMojo extends NjordMojoSupport {
+    /**
+     * The name of the store to publish.
+     */
+    @Parameter(required = true, property = "store")
+    protected String store;
+
+    /**
+     * The name of the publisher to publish to.
+     */
+    @Parameter(required = true, property = "target")
+    protected String target;
+
+    protected ArtifactStore getArtifactStore(NjordSession ns) throws IOException, MojoFailureException {
+        Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
+        if (storeOptional.isEmpty()) {
+            logger.warn("ArtifactStore with given name not found: {}", store);
+            throw new MojoFailureException("ArtifactStore with given name not found: " + store);
+        }
+        return storeOptional.orElseThrow();
+    }
+
+    protected ArtifactStorePublisher getArtifactStorePublisher(NjordSession ns) throws MojoFailureException {
+        Optional<ArtifactStorePublisher> po = ns.selectArtifactStorePublisher(target);
+        if (po.isEmpty()) {
+            throw new MojoFailureException("Publisher not found");
+        }
+        return po.orElseThrow();
+    }
+}

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
@@ -7,8 +7,6 @@
  */
 package eu.maveniverse.maven.njord.plugin3;
 
-import static eu.maveniverse.maven.njord.shared.Config.NJORD_PREFIX;
-
 import eu.maveniverse.maven.njord.shared.NjordSession;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
@@ -36,20 +34,17 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
 
     protected ArtifactStore getArtifactStore(NjordSession ns) throws IOException, MojoFailureException {
         if (store == null) {
-            logger.info("No store name specified, using heuristic to find store");
-            if (ns.sessionConfig().config().effectiveProperties().containsKey(NJORD_PREFIX)) {
-                String prefix =
-                        ns.sessionConfig().config().effectiveProperties().get(NJORD_PREFIX);
-                if (prefix != null) {
-                    List<String> storeNames = ns.artifactStoreManager().listArtifactStoreNamesForPrefix(prefix);
-                    if (!storeNames.isEmpty()) {
-                        if (storeNames.size() == 1) {
-                            store = storeNames.get(0);
-                            logger.info("Found one store, using it: '{}'", store);
-                        } else {
-                            store = storeNames.get(storeNames.size() - 1);
-                            logger.info("Found multiple stores, using latest: '{}'", store);
-                        }
+            if (ns.sessionConfig().prefix().isPresent()) {
+                logger.info("No store name specified but prefix is set; using heuristic to find store");
+                String prefix = ns.sessionConfig().prefix().orElseThrow();
+                List<String> storeNames = ns.artifactStoreManager().listArtifactStoreNamesForPrefix(prefix);
+                if (!storeNames.isEmpty()) {
+                    if (storeNames.size() == 1) {
+                        store = storeNames.get(0);
+                        logger.info("Found one store, using it: '{}'", store);
+                    } else {
+                        store = storeNames.get(storeNames.size() - 1);
+                        logger.info("Found multiple stores, using latest: '{}'", store);
                     }
                 }
             }


### PR DESCRIPTION
Before, it was template prefix that was always used to name store. This PR changes that, by introducing 3 things:
* `njord.autoprefix` - if enabled (by default is), prefix defaults to TLPOM artifactId, unless explicitly given (see below)
* `njord.prefix` - can be system, user or project property, defines prefix for stores created within session explicitly
* `njord.target` - can be system, user or project property, defines target for publishing.

This allows invoking `njord:publish` without any parameter, but also improves UX when locally staging multiple projects as stores will carry their TLPOM artifactId as prefix.

If prefix is configured (or autoprefix enabled), heuristic will look for "latest" staged store with given prefix, and will select that one for publishing.

Fixes #35 
Fixes #34 