### PR TITLE
Support project server.id

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -42,19 +42,49 @@ public interface SessionConfig {
 
     String KEY_PREFIX = NAME + ".";
 
+    /**
+     * Configuration key in properties (system, user or project) to enable/disable Njord. Defaults to {@code true}.
+     */
     String CONFIG_ENABLED = KEY_PREFIX + "enabled";
 
+    /**
+     * Configuration key in properties (system, user or project) for "dry run". Defaults to {@code false}.
+     */
     String CONFIG_DRY_RUN = KEY_PREFIX + "dryRun";
 
+    /**
+     * Configuration key in properties (system, user or project) for "auto prefix": if project is present, use its top
+     * level project artifact id as prefix. Defaults to {@code true}.
+     */
     String CONFIG_AUTOPREFIX = KEY_PREFIX + "autoprefix";
 
+    /**
+     * Configuration key in properties (system, user or project) for explicitly set prefix to use. If {@link #CONFIG_AUTOPREFIX}
+     * is {@code true} and there is a project in context, prefix will be automatically set to top level project artifact id.
+     */
     String CONFIG_PREFIX = KEY_PREFIX + "prefix";
 
+    /**
+     * Configuration key in {@code settings/servers/server/configuration} or properties (system, user or project)
+     * for publisher to use with this server.
+     */
     String CONFIG_PUBLISHER = KEY_PREFIX + "publisher";
 
+    /**
+     * Configuration key in {@code settings/servers/server/configuration} for release Njord URL.
+     */
     String CONFIG_RELEASE_URL = KEY_PREFIX + "releaseUrl";
 
+    /**
+     * Configuration key in {@code settings/servers/server/configuration} for snapshot Njord URL.
+     */
     String CONFIG_SNAPSHOT_URL = KEY_PREFIX + "snapshotUrl";
+
+    /**
+     * Configuration key in {@code settings/servers/server/configuration} for authentication redirect. If this
+     * key is present, Njord will take authentication from redirected server entry instead.
+     */
+    String CONFIG_AUTH_REDIRECT = KEY_PREFIX + "authRedirect";
 
     /**
      * Is Njord enabled? If this method returns {@code false}, Njord will step aside (like it was not loaded).

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/deploy/ArtifactDeployerRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/deploy/ArtifactDeployerRedirector.java
@@ -7,7 +7,7 @@
  */
 package eu.maveniverse.maven.njord.shared.deploy;
 
-import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import org.eclipse.aether.repository.RemoteRepository;
 
@@ -16,11 +16,16 @@ public interface ArtifactDeployerRedirector {
      * Tells, based on Njord config, what is the real URL used for given remote repository. Never returns {@code null},
      * and without any configuration just returns passed in repository URL.
      */
-    String getRepositoryUrl(Session ns, RemoteRepository repository);
+    String getRepositoryUrl(SessionConfig sc, RemoteRepository repository);
 
     /**
      * Tells, based on Njord config, what is the real URL used for given remote repository. Never returns {@code null},
      * and without any configuration just returns passed in repository URL.
      */
-    String getRepositoryUrl(Session ns, RemoteRepository repository, RepositoryMode repositoryMode);
+    String getRepositoryUrl(SessionConfig sc, RemoteRepository repository, RepositoryMode repositoryMode);
+
+    /**
+     * Returns the remote repository to source auth from for the passed in remote repository. Never returns {@code null}.
+     */
+    RemoteRepository getAuthRepositoryId(SessionConfig sc, RemoteRepository repository);
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/PublisherConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/PublisherConfig.java
@@ -10,7 +10,9 @@ package eu.maveniverse.maven.njord.shared.publisher;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import java.util.Map;
+import org.eclipse.aether.repository.RemoteRepository;
 
 public class PublisherConfig {
     private final String releaseRepositoryId;
@@ -37,6 +39,22 @@ public class PublisherConfig {
                 "njord.publisher." + name + ".snapshotRepositoryId", defaultSnapshotRepositoryId);
         this.snapshotRepositoryUrl = effectiveProperties.getOrDefault(
                 "njord.publisher." + name + ".snapshotRepositoryUrl", defaultSnapshotRepositoryUrl);
+    }
+
+    protected static String repositoryId(SessionConfig sessionConfig, RepositoryMode mode, String defaultRepositoryId) {
+        requireNonNull(sessionConfig);
+        requireNonNull(mode);
+        if (sessionConfig.currentProject().isPresent()) {
+            RemoteRepository repository = sessionConfig
+                    .currentProject()
+                    .orElseThrow()
+                    .distributionManagementRepositories()
+                    .get(mode);
+            if (repository != null) {
+                return repository.getId();
+            }
+        }
+        return defaultRepositoryId;
     }
 
     public String releaseRepositoryId() {

--- a/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordRepositoryConnectorFactory.java
+++ b/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordRepositoryConnectorFactory.java
@@ -62,7 +62,7 @@ public class NjordRepositoryConnectorFactory implements RepositoryConnectorFacto
                             .config()
                             .enabled()) {
                 Session ns = nso.orElseThrow(() -> new IllegalStateException("Value unavailable"));
-                String url = artifactDeployerRedirector.getRepositoryUrl(ns, repository);
+                String url = artifactDeployerRedirector.getRepositoryUrl(ns.config(), repository);
                 if (url != null && url.startsWith(NAME + ":")) {
                     ArtifactStore artifactStore = ns.getOrCreateSessionArtifactStore(url.substring(6));
                     return new NjordRepositoryConnector(

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
@@ -83,7 +83,7 @@ public class StatusMojo extends PublisherSupportMojo {
         logger.info("  ID: {}", deploymentRelease.getId());
         RemoteRepository releaseAuthSource =
                 artifactDeployerRedirector.getAuthRepositoryId(ns.config(), deploymentRelease);
-        if (releaseAuthSource != deploymentRelease) {
+        if (!Objects.equals(releaseAuthSource.getId(), deploymentRelease.getId())) {
             logger.info("  Auth source: {}", releaseAuthSource.getId());
         }
         logger.info("  POM URL: {}", deploymentRelease.getUrl());
@@ -100,7 +100,7 @@ public class StatusMojo extends PublisherSupportMojo {
         logger.info("  ID: {}", deploymentSnapshot.getId());
         RemoteRepository snapshotAuthSource =
                 artifactDeployerRedirector.getAuthRepositoryId(ns.config(), deploymentSnapshot);
-        if (snapshotAuthSource != deploymentSnapshot) {
+        if (!Objects.equals(snapshotAuthSource.getId(), deploymentSnapshot.getId())) {
             logger.info("  Auth source: {}", snapshotAuthSource.getId());
         }
         logger.info("  POM URL: {}", deploymentSnapshot.getUrl());

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
@@ -79,12 +79,12 @@ public class StatusMojo extends PublisherSupportMojo {
                 artifactDeployerRedirector.getRepositoryUrl(ns.config(), deploymentSnapshot, RepositoryMode.SNAPSHOT);
 
         logger.info("Project deployment:");
-        logger.info("* RELEASE");
-        logger.info("  ID: {}", deploymentRelease.getId());
+        logger.info("* Release");
+        logger.info("  Repository Id: {}", deploymentRelease.getId());
         RemoteRepository releaseAuthSource =
                 artifactDeployerRedirector.getAuthRepositoryId(ns.config(), deploymentRelease);
         if (!Objects.equals(releaseAuthSource.getId(), deploymentRelease.getId())) {
-            logger.info("  Auth source: {}", releaseAuthSource.getId());
+            logger.info("  Auth source Id: {}", releaseAuthSource.getId());
         }
         logger.info("  POM URL: {}", deploymentRelease.getUrl());
         if (!Objects.equals(deploymentRelease.getUrl(), deploymentReleaseUrl)) {
@@ -92,16 +92,15 @@ public class StatusMojo extends PublisherSupportMojo {
             if (deploymentReleaseUrl.startsWith("njord:")) {
                 ArtifactStoreTemplate template =
                         ns.selectSessionArtifactStoreTemplate(deploymentReleaseUrl.substring("njord:".length()));
-                logger.info("  Template:");
                 printTemplate(template, false);
             }
         }
-        logger.info("* SNAPSHOT");
-        logger.info("  ID: {}", deploymentSnapshot.getId());
+        logger.info("* Snapshot");
+        logger.info("  Repository Id: {}", deploymentSnapshot.getId());
         RemoteRepository snapshotAuthSource =
                 artifactDeployerRedirector.getAuthRepositoryId(ns.config(), deploymentSnapshot);
         if (!Objects.equals(snapshotAuthSource.getId(), deploymentSnapshot.getId())) {
-            logger.info("  Auth source: {}", snapshotAuthSource.getId());
+            logger.info("  Auth source Id: {}", snapshotAuthSource.getId());
         }
         logger.info("  POM URL: {}", deploymentSnapshot.getUrl());
         if (!Objects.equals(deploymentSnapshot.getUrl(), deploymentSnapshotUrl)) {

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
@@ -74,13 +74,18 @@ public class StatusMojo extends PublisherSupportMojo {
                 .setReleasePolicy(new RepositoryPolicy(false, null, null))
                 .build();
         String deploymentReleaseUrl =
-                artifactDeployerRedirector.getRepositoryUrl(ns, deploymentRelease, RepositoryMode.RELEASE);
+                artifactDeployerRedirector.getRepositoryUrl(ns.config(), deploymentRelease, RepositoryMode.RELEASE);
         String deploymentSnapshotUrl =
-                artifactDeployerRedirector.getRepositoryUrl(ns, deploymentSnapshot, RepositoryMode.SNAPSHOT);
+                artifactDeployerRedirector.getRepositoryUrl(ns.config(), deploymentSnapshot, RepositoryMode.SNAPSHOT);
 
         logger.info("Project deployment:");
         logger.info("* RELEASE");
         logger.info("  ID: {}", deploymentRelease.getId());
+        RemoteRepository releaseAuthSource =
+                artifactDeployerRedirector.getAuthRepositoryId(ns.config(), deploymentRelease);
+        if (releaseAuthSource != deploymentRelease) {
+            logger.info("  Auth source: {}", releaseAuthSource.getId());
+        }
         logger.info("  POM URL: {}", deploymentRelease.getUrl());
         if (!Objects.equals(deploymentRelease.getUrl(), deploymentReleaseUrl)) {
             logger.info("  Effective URL: {}", deploymentReleaseUrl);
@@ -93,6 +98,11 @@ public class StatusMojo extends PublisherSupportMojo {
         }
         logger.info("* SNAPSHOT");
         logger.info("  ID: {}", deploymentSnapshot.getId());
+        RemoteRepository snapshotAuthSource =
+                artifactDeployerRedirector.getAuthRepositoryId(ns.config(), deploymentSnapshot);
+        if (snapshotAuthSource != deploymentSnapshot) {
+            logger.info("  Auth source: {}", snapshotAuthSource.getId());
+        }
         logger.info("  POM URL: {}", deploymentSnapshot.getUrl());
         if (!Objects.equals(deploymentSnapshot.getUrl(), deploymentSnapshotUrl)) {
             logger.info("  Effective URL: {}", deploymentSnapshotUrl);

--- a/publisher/apache/src/main/java/eu/maveniverse/maven/njord/publisher/apache/ApachePublisherConfig.java
+++ b/publisher/apache/src/main/java/eu/maveniverse/maven/njord/publisher/apache/ApachePublisherConfig.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.publisher.apache;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
 public final class ApachePublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "apache.releases.https";
@@ -21,9 +22,9 @@ public final class ApachePublisherConfig extends PublisherConfig {
         super(
                 sessionConfig,
                 ApacheRaoPublisherFactory.NAME,
-                RELEASE_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.RELEASE, RELEASE_REPOSITORY_ID),
                 RELEASE_REPOSITORY_URL,
-                SNAPSHOT_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.SNAPSHOT, SNAPSHOT_REPOSITORY_ID),
                 SNAPSHOT_REPOSITORY_URL);
     }
 }

--- a/publisher/apache/src/main/java/eu/maveniverse/maven/njord/publisher/apache/ApacheRaoPublisherFactory.java
+++ b/publisher/apache/src/main/java/eu/maveniverse/maven/njord/publisher/apache/ApacheRaoPublisherFactory.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 import eu.maveniverse.maven.njord.publisher.sonatype.SonatypeCentralRequirementsFactory;
 import eu.maveniverse.maven.njord.publisher.sonatype.SonatypeNx2Publisher;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.deploy.ArtifactDeployerRedirector;
 import eu.maveniverse.maven.njord.shared.publisher.MavenCentralPublisherFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,12 +28,16 @@ public class ApacheRaoPublisherFactory implements MavenCentralPublisherFactory {
 
     private final RepositorySystem repositorySystem;
     private final SonatypeCentralRequirementsFactory centralRequirementsFactory;
+    private final ArtifactDeployerRedirector artifactDeployerRedirector;
 
     @Inject
     public ApacheRaoPublisherFactory(
-            RepositorySystem repositorySystem, SonatypeCentralRequirementsFactory centralRequirementsFactory) {
+            RepositorySystem repositorySystem,
+            SonatypeCentralRequirementsFactory centralRequirementsFactory,
+            ArtifactDeployerRedirector artifactDeployerRedirector) {
         this.repositorySystem = requireNonNull(repositorySystem);
         this.centralRequirementsFactory = requireNonNull(centralRequirementsFactory);
+        this.artifactDeployerRedirector = requireNonNull(artifactDeployerRedirector);
     }
 
     @Override
@@ -62,6 +67,7 @@ public class ApacheRaoPublisherFactory implements MavenCentralPublisherFactory {
                 snapshotsRepository,
                 releasesRepository,
                 snapshotsRepository,
-                centralRequirementsFactory.create(sessionConfig));
+                centralRequirementsFactory.create(sessionConfig),
+                artifactDeployerRedirector);
     }
 }

--- a/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
+++ b/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.publisher.deploy;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.deploy.ArtifactDeployerRedirector;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherFactory;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
@@ -29,10 +30,13 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
     private static final String PROP_ALT_DEPLOYMENT_REPOSITORY = "altDeploymentRepository";
 
     private final RepositorySystem repositorySystem;
+    private final ArtifactDeployerRedirector artifactDeployerRedirector;
 
     @Inject
-    public DeployPublisherFactory(RepositorySystem repositorySystem) {
+    public DeployPublisherFactory(
+            RepositorySystem repositorySystem, ArtifactDeployerRedirector artifactDeployerRedirector) {
         this.repositorySystem = requireNonNull(repositorySystem);
+        this.artifactDeployerRedirector = requireNonNull(artifactDeployerRedirector);
     }
 
     @Override
@@ -66,6 +70,7 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
                 repositorySystem,
                 releasesRepository,
                 snapshotsRepository,
-                ArtifactStoreRequirements.NONE);
+                ArtifactStoreRequirements.NONE,
+                artifactDeployerRedirector);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -76,13 +76,12 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 }
 
                 // build auth token
+                RemoteRepository authSource = artifactDeployerRedirector.getAuthRepositoryId(sessionConfig, repository);
                 String authKey = "Authorization";
                 String authValue = null;
                 try (AuthenticationContext repoAuthContext = AuthenticationContext.forRepository(
                         sessionConfig.session(),
-                        repositorySystem.newDeploymentRepository(
-                                sessionConfig.session(),
-                                artifactDeployerRedirector.getAuthRepositoryId(sessionConfig, repository)))) {
+                        repositorySystem.newDeploymentRepository(sessionConfig.session(), authSource))) {
                     if (repoAuthContext != null) {
                         String username = repoAuthContext.get(AuthenticationContext.USERNAME);
                         String password = repoAuthContext.get(AuthenticationContext.PASSWORD);
@@ -93,7 +92,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 }
                 if (authValue == null) {
                     throw new IllegalStateException(
-                            "No authorization information found for repository " + repository.getId());
+                            "No authorization information found for repository " + authSource.getId());
                 }
 
                 // we need to use own HTTP client here

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
 public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-cp";
@@ -20,9 +21,9 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
         super(
                 sessionConfig,
                 SonatypeCentralPortalPublisherFactory.NAME,
-                RELEASE_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.RELEASE, RELEASE_REPOSITORY_ID),
                 RELEASE_REPOSITORY_URL,
-                SNAPSHOT_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.SNAPSHOT, SNAPSHOT_REPOSITORY_ID),
                 SNAPSHOT_REPOSITORY_URL);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherFactory.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherFactory.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.deploy.ArtifactDeployerRedirector;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.MavenCentralPublisherFactory;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriterFactory;
@@ -26,15 +27,18 @@ public class SonatypeCentralPortalPublisherFactory implements MavenCentralPublis
     public static final String NAME = "sonatype-cp";
 
     private final RepositorySystem repositorySystem;
+    private final ArtifactDeployerRedirector artifactDeployerRedirector;
     private final ArtifactStoreWriterFactory artifactStoreWriterFactory;
     private final SonatypeCentralRequirementsFactory centralRequirementsFactory;
 
     @Inject
     public SonatypeCentralPortalPublisherFactory(
             RepositorySystem repositorySystem,
+            ArtifactDeployerRedirector artifactDeployerRedirector,
             ArtifactStoreWriterFactory artifactStoreWriterFactory,
             SonatypeCentralRequirementsFactory centralRequirementsFactory) {
         this.repositorySystem = requireNonNull(repositorySystem);
+        this.artifactDeployerRedirector = requireNonNull(artifactDeployerRedirector);
         this.artifactStoreWriterFactory = requireNonNull(artifactStoreWriterFactory);
         this.centralRequirementsFactory = requireNonNull(centralRequirementsFactory);
     }
@@ -63,6 +67,7 @@ public class SonatypeCentralPortalPublisherFactory implements MavenCentralPublis
                 releasesRepository,
                 snapshotsRepository,
                 centralRequirementsFactory.create(sessionConfig),
-                artifactStoreWriterFactory);
+                artifactStoreWriterFactory,
+                artifactDeployerRedirector);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeOSSPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeOSSPublisherConfig.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
 public final class SonatypeOSSPublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-oss";
@@ -20,9 +21,9 @@ public final class SonatypeOSSPublisherConfig extends PublisherConfig {
         super(
                 sessionConfig,
                 SonatypeOSSPublisherFactory.NAME,
-                RELEASE_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.RELEASE, RELEASE_REPOSITORY_ID),
                 RELEASE_REPOSITORY_URL,
-                SNAPSHOT_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.SNAPSHOT, SNAPSHOT_REPOSITORY_ID),
                 SNAPSHOT_REPOSITORY_URL);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeOSSPublisherFactory.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeOSSPublisherFactory.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.deploy.ArtifactDeployerRedirector;
 import eu.maveniverse.maven.njord.shared.publisher.MavenCentralPublisherFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -25,12 +26,16 @@ public class SonatypeOSSPublisherFactory implements MavenCentralPublisherFactory
 
     private final RepositorySystem repositorySystem;
     private final SonatypeCentralRequirementsFactory centralRequirementsFactory;
+    private final ArtifactDeployerRedirector artifactDeployerRedirector;
 
     @Inject
     public SonatypeOSSPublisherFactory(
-            RepositorySystem repositorySystem, SonatypeCentralRequirementsFactory centralRequirementsFactory) {
+            RepositorySystem repositorySystem,
+            SonatypeCentralRequirementsFactory centralRequirementsFactory,
+            ArtifactDeployerRedirector artifactDeployerRedirector) {
         this.repositorySystem = requireNonNull(repositorySystem);
         this.centralRequirementsFactory = requireNonNull(centralRequirementsFactory);
+        this.artifactDeployerRedirector = requireNonNull(artifactDeployerRedirector);
     }
 
     @Override
@@ -60,6 +65,7 @@ public class SonatypeOSSPublisherFactory implements MavenCentralPublisherFactory
                 snapshotsRepository,
                 releasesRepository,
                 snapshotsRepository,
-                centralRequirementsFactory.create(sessionConfig));
+                centralRequirementsFactory.create(sessionConfig),
+                artifactDeployerRedirector);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeS01PublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeS01PublisherConfig.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
 public final class SonatypeS01PublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-s01";
@@ -21,9 +22,9 @@ public final class SonatypeS01PublisherConfig extends PublisherConfig {
         super(
                 sessionConfig,
                 SonatypeS01PublisherFactory.NAME,
-                RELEASE_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.RELEASE, RELEASE_REPOSITORY_ID),
                 RELEASE_REPOSITORY_URL,
-                SNAPSHOT_REPOSITORY_ID,
+                repositoryId(sessionConfig, RepositoryMode.SNAPSHOT, SNAPSHOT_REPOSITORY_ID),
                 SNAPSHOT_REPOSITORY_URL);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeS01PublisherFactory.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeS01PublisherFactory.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.deploy.ArtifactDeployerRedirector;
 import eu.maveniverse.maven.njord.shared.publisher.MavenCentralPublisherFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -25,12 +26,16 @@ public class SonatypeS01PublisherFactory implements MavenCentralPublisherFactory
 
     private final RepositorySystem repositorySystem;
     private final SonatypeCentralRequirementsFactory centralRequirementsFactory;
+    private final ArtifactDeployerRedirector artifactDeployerRedirector;
 
     @Inject
     public SonatypeS01PublisherFactory(
-            RepositorySystem repositorySystem, SonatypeCentralRequirementsFactory centralRequirementsFactory) {
+            RepositorySystem repositorySystem,
+            SonatypeCentralRequirementsFactory centralRequirementsFactory,
+            ArtifactDeployerRedirector artifactDeployerRedirector) {
         this.repositorySystem = requireNonNull(repositorySystem);
         this.centralRequirementsFactory = requireNonNull(centralRequirementsFactory);
+        this.artifactDeployerRedirector = requireNonNull(artifactDeployerRedirector);
     }
 
     @Override
@@ -60,6 +65,7 @@ public class SonatypeS01PublisherFactory implements MavenCentralPublisherFactory
                 snapshotsRepository,
                 releasesRepository,
                 snapshotsRepository,
-                centralRequirementsFactory.create(sessionConfig));
+                centralRequirementsFactory.create(sessionConfig),
+                artifactDeployerRedirector);
     }
 }


### PR DESCRIPTION
Before the publishers had fixed IDs, and it was required to have these fixed entries in your settings.xml with auth equipped.

Now, project distMgt server IDs are used instead, but auth can be "redirected" with a new property.

Fixes #53 
Fixes #57 
Fixes #60 