### PR TITLE
Ensure basedir is present

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -426,7 +426,15 @@ public interface SessionConfig {
                 this.enabled = enabled;
                 this.dryRun = dryRun;
                 this.version = version;
-                this.basedir = requireNonNull(basedir, "basedir");
+                this.basedir = getCanonicalPath(basedir);
+                if (!Files.isDirectory(this.basedir)) {
+                    try {
+                        Files.createDirectories(this.basedir);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException("Cannot create basedir", e);
+                    }
+                }
+
                 requireNonNull(propertiesPath, "propertiesPath");
                 this.propertiesPath = getCanonicalPath(basedir.resolve(propertiesPath));
 
@@ -435,7 +443,7 @@ public interface SessionConfig {
                     try (InputStream inputStream = Files.newInputStream(this.propertiesPath)) {
                         properties.load(inputStream);
                     } catch (IOException e) {
-                        throw new UncheckedIOException(e);
+                        throw new UncheckedIOException("Cannot load properties", e);
                     }
                 }
 


### PR DESCRIPTION
When creating session, the basedir must already
be present, create it if not.

Fixes #56 