### PR TITLE
Dynamic template selection

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
@@ -118,8 +118,14 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
         try {
             if (!uri.contains(":")) {
                 if (uri.isEmpty()) {
-                    // empty -> default
-                    return internalArtifactStoreManager.defaultTemplate();
+                    // empty -> default IF project is available
+                    if (config.currentProject().isPresent()) {
+                        return internalArtifactStoreManager.defaultTemplate(
+                                config.currentProject().orElseThrow().repositoryMode());
+                    } else {
+                        throw new IllegalStateException(
+                                "No project present, cannot deduce repository mode: specify template explicitly as `njord:template:<TEMPLATE>`");
+                    }
                 } else {
                     // non-empty -> template name
                     return selectTemplate(uri);
@@ -153,9 +159,17 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
                 String artifactStoreName;
                 if (!uri.contains(":")) {
                     if (uri.isEmpty()) {
-                        // empty -> default
-                        artifactStoreName = createUsingTemplate(
-                                internalArtifactStoreManager.defaultTemplate().name());
+                        // empty -> default IF project is available
+                        if (config.currentProject().isPresent()) {
+                            artifactStoreName = createUsingTemplate(internalArtifactStoreManager
+                                    .defaultTemplate(config.currentProject()
+                                            .orElseThrow()
+                                            .repositoryMode())
+                                    .name());
+                        } else {
+                            throw new IllegalStateException(
+                                    "No project present, cannot deduce repository mode: specify template explicitly as `njord:template:<TEMPLATE>`");
+                        }
                     } else {
                         // non-empty -> template name
                         artifactStoreName = createUsingTemplate(uri);

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultInternalArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultInternalArtifactStoreManager.java
@@ -108,10 +108,18 @@ public class DefaultInternalArtifactStoreManager extends CloseableConfigSupport<
     }
 
     @Override
-    public ArtifactStoreTemplate defaultTemplate() {
+    public ArtifactStoreTemplate defaultTemplate(RepositoryMode repositoryMode) {
         checkClosed();
+        requireNonNull(repositoryMode);
 
-        return ArtifactStoreTemplate.RELEASE_SCA;
+        switch (repositoryMode) {
+            case RELEASE:
+                return ArtifactStoreTemplate.RELEASE_SCA;
+            case SNAPSHOT:
+                return ArtifactStoreTemplate.SNAPSHOT_SCA;
+            default:
+                throw new IllegalArgumentException("Unsupported repository mode: " + repositoryMode);
+        }
     }
 
     @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
@@ -32,9 +32,9 @@ public interface ArtifactStoreManager {
     Optional<ArtifactStore> selectArtifactStore(String name) throws IOException;
 
     /**
-     * Returns the default template.
+     * Returns the default template for given repository mode.
      */
-    ArtifactStoreTemplate defaultTemplate();
+    ArtifactStoreTemplate defaultTemplate(RepositoryMode repositoryMode);
 
     /**
      * List templates.

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListTemplatesMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListTemplatesMojo.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -22,9 +23,12 @@ public class ListTemplatesMojo extends NjordMojoSupport {
     protected void doWithSession(Session ns) throws IOException {
         logger.info("List of existing ArtifactStoreTemplate:");
         Collection<ArtifactStoreTemplate> templates = ns.artifactStoreManager().listTemplates();
-        ArtifactStoreTemplate defaultTemplate = ns.artifactStoreManager().defaultTemplate();
+        ArtifactStoreTemplate defaultReleaseTemplate =
+                ns.artifactStoreManager().defaultTemplate(RepositoryMode.RELEASE);
+        ArtifactStoreTemplate defaultSnapshotTemplate =
+                ns.artifactStoreManager().defaultTemplate(RepositoryMode.SNAPSHOT);
         for (ArtifactStoreTemplate template : templates) {
-            printTemplate(template, template == defaultTemplate);
+            printTemplate(template, template == defaultReleaseTemplate || template == defaultSnapshotTemplate);
         }
         logger.info("Total of {} ArtifactStoreTemplate.", templates.size());
     }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
@@ -54,7 +54,10 @@ public abstract class NjordMojoSupport extends MojoSupport {
     }
 
     protected void printTemplate(ArtifactStoreTemplate template, boolean defaultTemplate) {
-        logger.info("- {} {}", template.name(), defaultTemplate ? " (default)" : " ");
+        logger.info(
+                "- {} {}",
+                template.name(),
+                defaultTemplate ? " (default " + template.repositoryMode().name() + ")" : " ");
         logger.info("    Default prefix: '{}'", template.prefix());
         logger.info("    Allow redeploy: {}", template.allowRedeploy());
         logger.info(


### PR DESCRIPTION
Instead to have "default" template always as release, select default based on project.

If no project present, user still can use full Njord URI like `njord:template:<TEMPLATE>`.

Fixes #68 