### PR TITLE
Validate output

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStoreValidator.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStoreValidator.java
@@ -41,6 +41,14 @@ public interface ArtifactStoreValidator {
                     + children().stream().map(ValidationResult::warningCount).reduce(0, Integer::sum);
         }
 
+        /**
+         * Total error count (this instance and all children).
+         */
+        default int errorCount() {
+            return error().size()
+                    + children().stream().map(ValidationResult::errorCount).reduce(0, Integer::sum);
+        }
+
         String name();
 
         Collection<String> info();


### PR DESCRIPTION
By default it prints only the outcome, as before.
With -Ddetails will print out ONLY failures.
With -Ddetails -Dfull will pring out ALL the
checks (failed ones but succeeded ones as well).

Fixes #69