### PR TITLE
Prefix should be A-V-N

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -529,7 +529,8 @@ public interface SessionConfig {
                 if (prefixString == null && currentProject != null) {
                     prefixString = currentProject.projectProperties().get(CONFIG_PREFIX);
                     if (prefixString == null && autoPrefix) {
-                        prefixString = currentProject.artifact().getArtifactId();
+                        prefixString = currentProject.artifact().getArtifactId() + "-"
+                                + currentProject.artifact().getVersion();
                     }
                 }
                 this.prefix = prefixString;


### PR DESCRIPTION
It seems the ZIP file is used by CP publisher.

This changes prefix to A-V-N

But this may cause problem in handling local staging reposes. Maybe better would be to _rename_ the bundle before POSTing it?