### PR TITLE
sonatype-cp: bundle name

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/PublisherConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/PublisherConfig.java
@@ -31,14 +31,20 @@ public class PublisherConfig {
         requireNonNull(name);
 
         Map<String, String> effectiveProperties = sessionConfig.effectiveProperties();
-        this.releaseRepositoryId = effectiveProperties.getOrDefault(
-                "njord.publisher." + name + ".releaseRepositoryId", defaultReleaseRepositoryId);
-        this.releaseRepositoryUrl = effectiveProperties.getOrDefault(
-                "njord.publisher." + name + ".releaseRepositoryUrl", defaultReleaseRepositoryUrl);
-        this.snapshotRepositoryId = effectiveProperties.getOrDefault(
-                "njord.publisher." + name + ".snapshotRepositoryId", defaultSnapshotRepositoryId);
-        this.snapshotRepositoryUrl = effectiveProperties.getOrDefault(
-                "njord.publisher." + name + ".snapshotRepositoryUrl", defaultSnapshotRepositoryUrl);
+        this.releaseRepositoryId =
+                effectiveProperties.getOrDefault(keyName(name, "releaseRepositoryId"), defaultReleaseRepositoryId);
+        this.releaseRepositoryUrl =
+                effectiveProperties.getOrDefault(keyName(name, "releaseRepositoryUrl"), defaultReleaseRepositoryUrl);
+        this.snapshotRepositoryId =
+                effectiveProperties.getOrDefault(keyName(name, "snapshotRepositoryId"), defaultSnapshotRepositoryId);
+        this.snapshotRepositoryUrl =
+                effectiveProperties.getOrDefault(keyName(name, "snapshotRepositoryUrl"), defaultSnapshotRepositoryUrl);
+    }
+
+    protected static String keyName(String name, String property) {
+        requireNonNull(name);
+        requireNonNull(property);
+        return "njord.publisher." + name + "." + property;
     }
 
     protected static String repositoryId(SessionConfig sessionConfig, RepositoryMode mode, String defaultRepositoryId) {

--- a/publisher/apache/src/main/java/eu/maveniverse/maven/njord/publisher/apache/ApachePublisherConfig.java
+++ b/publisher/apache/src/main/java/eu/maveniverse/maven/njord/publisher/apache/ApachePublisherConfig.java
@@ -11,6 +11,20 @@ import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
+/**
+ * ASF repository.apache.org config.
+ * <p>
+ * User usually does not want to fiddle with these (as this is SaaS, so URLs are fixed).
+ * Properties supported:
+ * <ul>
+ *     <li><code>njord.publisher.apache-rao.releaseRepositoryId</code> - the release service server.id</li>
+ *     <li><code>njord.publisher.apache-rao.releaseRepositoryUrl</code> - the release service URL</li>
+ *     <li><code>njord.publisher.apache-rao.snapshotRepositoryId</code> - the snapshot service server.id</li>
+ *     <li><code>njord.publisher.apache-rao.snapshotRepositoryUrl</code> - the snapshot service URL</li>
+ * </ul>
+ * If you are ASF publisher using Maven, you are most probably already set up, as <code>server.id</code> used
+ * by default matches with those on ASF Maven Parent POM.
+ */
 public final class ApachePublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "apache.releases.https";
     public static final String RELEASE_REPOSITORY_URL =

--- a/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
+++ b/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
@@ -22,6 +22,17 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 
+/**
+ * The "deploy" publisher deploy as "Maven would do", but it operates on staged artifact store, no need to
+ * invoke the build for it.
+ * <p>
+ * It obeys one familiar property: <code>altDeploymentRepository</code> and very same syntax as Maven Deploy Plugin
+ * <code>id::url</code>. This implies that one can "deploy publish" any artifact store with command like this:
+ * <pre>
+ *   $ mvn njord:publish -Dpublisher=deploy -DaltDeploymentRepository=myserver::myurl
+ * </pre>
+ * And it simply deploys to given repository "as Maven would do".
+ */
 @Singleton
 @Named(DeployPublisherFactory.NAME)
 public class DeployPublisherFactory implements ArtifactStorePublisherFactory {

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -85,6 +85,11 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 String bundleName = bundle.getFileName().toString();
                 if (publisherConfig.bundleName().isPresent()) {
                     bundleName = publisherConfig.bundleName().orElseThrow();
+                } else if (sessionConfig.currentProject().isPresent()) {
+                    SessionConfig.CurrentProject cp =
+                            sessionConfig.currentProject().orElseThrow();
+                    bundleName =
+                            cp.artifact().getArtifactId() + "-" + cp.artifact().getVersion();
                 }
 
                 // build auth token

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -26,8 +26,7 @@ import org.eclipse.aether.util.ConfigUtils;
  *     <li><code>njord.publisher.sonatype-cp.bundleName</code> (alias <code>njord.bundleName</code>) - the name to use for bundle</li>
  * </ul>
  * The property <code>njord.publisher.sonatype-cp.bundleName</code> defines the bundle name that is shown on CP WebUI.
- * Define it somehow, possible to be interpolated (in Maven or Maven Config, both are interpolated) to something
- * like <code>${project.artifactId}-${project.version}</code>.
+ * By default, value of <code>${project.artifactId}-${project.version}</code> is used IF current project is present.
  */
 public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-cp";

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -10,12 +10,32 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
+import java.util.Optional;
+import org.eclipse.aether.util.ConfigUtils;
 
+/**
+ * Sonatype Central Portal config.
+ * <p>
+ * User usually does not want to fiddle with these (as this is SaaS, so URLs are fixed).
+ * Properties supported:
+ * <ul>
+ *     <li><code>njord.publisher.sonatype-cp.releaseRepositoryId</code> - the release service server.id</li>
+ *     <li><code>njord.publisher.sonatype-cp.releaseRepositoryUrl</code> - the release service URL</li>
+ *     <li><code>njord.publisher.sonatype-cp.snapshotRepositoryId</code> - the snapshot service server.id</li>
+ *     <li><code>njord.publisher.sonatype-cp.snapshotRepositoryUrl</code> - the snapshot service URL</li>
+ *     <li><code>njord.publisher.sonatype-cp.bundleName</code> (alias <code>njord.bundleName</code>) - the name to use for bundle</li>
+ * </ul>
+ * The property <code>njord.publisher.sonatype-cp.bundleName</code> defines the bundle name that is shown on CP WebUI.
+ * Define it somehow, possible to be interpolated (in Maven or Maven Config, both are interpolated) to something
+ * like <code>${project.artifactId}-${project.version}</code>.
+ */
 public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-cp";
     public static final String RELEASE_REPOSITORY_URL = "https://central.sonatype.com/api/v1/publisher/upload";
     public static final String SNAPSHOT_REPOSITORY_ID = "sonatype-cp";
     public static final String SNAPSHOT_REPOSITORY_URL = "https://central.sonatype.com/repository/maven-snapshots";
+
+    private final String bundleName;
 
     public SonatypeCentralPortalPublisherConfig(SessionConfig sessionConfig) {
         super(
@@ -25,5 +45,16 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
                 RELEASE_REPOSITORY_URL,
                 repositoryId(sessionConfig, RepositoryMode.SNAPSHOT, SNAPSHOT_REPOSITORY_ID),
                 SNAPSHOT_REPOSITORY_URL);
+
+        // njord.publisher.sonatype-cp.bundleName
+        this.bundleName = ConfigUtils.getString(
+                sessionConfig.effectiveProperties(),
+                null,
+                keyName(SonatypeCentralPortalPublisherFactory.NAME, "bundleName"),
+                SessionConfig.CONFIG_PREFIX + "bundleName");
+    }
+
+    public Optional<String> bundleName() {
+        return Optional.ofNullable(bundleName);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherFactory.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherFactory.java
@@ -67,6 +67,7 @@ public class SonatypeCentralPortalPublisherFactory implements MavenCentralPublis
                 releasesRepository,
                 snapshotsRepository,
                 centralRequirementsFactory.create(sessionConfig),
+                cpConfig,
                 artifactStoreWriterFactory,
                 artifactDeployerRedirector);
     }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeOSSPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeOSSPublisherConfig.java
@@ -11,6 +11,18 @@ import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
+/**
+ * Sonatype OSS config.
+ * <p>
+ * User usually does not want to fiddle with these (as this is SaaS, so URLs are fixed).
+ * Properties supported:
+ * <ul>
+ *     <li><code>njord.publisher.sonatype-oss.releaseRepositoryId</code> - the release service server.id</li>
+ *     <li><code>njord.publisher.sonatype-oss.releaseRepositoryUrl</code> - the release service URL</li>
+ *     <li><code>njord.publisher.sonatype-oss.snapshotRepositoryId</code> - the snapshot service server.id</li>
+ *     <li><code>njord.publisher.sonatype-oss.snapshotRepositoryUrl</code> - the snapshot service URL</li>
+ * </ul>
+ */
 public final class SonatypeOSSPublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-oss";
     public static final String RELEASE_REPOSITORY_URL = "https://oss.sonatype.org/service/local/staging/deploy/maven2";

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeS01PublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeS01PublisherConfig.java
@@ -11,6 +11,18 @@ import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.publisher.PublisherConfig;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 
+/**
+ * Sonatype S01 config.
+ * <p>
+ * User usually does not want to fiddle with these (as this is SaaS, so URLs are fixed).
+ * Properties supported:
+ * <ul>
+ *     <li><code>njord.publisher.sonatype-s01.releaseRepositoryId</code> - the release service server.id</li>
+ *     <li><code>njord.publisher.sonatype-s01.releaseRepositoryUrl</code> - the release service URL</li>
+ *     <li><code>njord.publisher.sonatype-s01.snapshotRepositoryId</code> - the snapshot service server.id</li>
+ *     <li><code>njord.publisher.sonatype-s01.snapshotRepositoryUrl</code> - the snapshot service URL</li>
+ * </ul>
+ */
 public final class SonatypeS01PublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-s01";
     public static final String RELEASE_REPOSITORY_URL =


### PR DESCRIPTION
It seems that CP service uses file name for display purposes. Allow users to customize it, as it may be misleading when same project publishes different major lineage at once.

So far njord used artifact store name, that is not the best. Now, the defaults are these:
* user can override it with `njord.publisher.sonatype-cp.bundleName` (alias `njord.bundleName`)
* IF not overridden, and IF project is present, use `${artifactId}-${version}`
* otherwise fallback to store name as before

Fixes #74 