### PR TITLE
Bugfix: Sonatype CP publisher named the bundle wrongly

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
@@ -229,8 +229,11 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
     }
 
     private String createUsingTemplate(String templateName) throws IOException {
-        try (ArtifactStore artifactStore =
-                internalArtifactStoreManager.createArtifactStore(selectTemplate(templateName))) {
+        try (ArtifactStore artifactStore = internalArtifactStoreManager.createArtifactStore(
+                selectTemplate(templateName),
+                config.currentProject().isPresent()
+                        ? config.currentProject().orElseThrow().artifact()
+                        : null)) {
             return artifactStore.name();
         }
     }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/PathArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/PathArtifactStore.java
@@ -52,6 +52,7 @@ public class PathArtifactStore extends CloseableSupport implements ArtifactStore
     private final boolean allowRedeploy;
     private final List<ChecksumAlgorithmFactory> checksumAlgorithmFactories;
     private final List<String> omitChecksumsForExtensions;
+    private final Artifact originProjectArtifact;
     private final Path basedir;
     private final DefaultLayout storeLayout;
 
@@ -63,6 +64,7 @@ public class PathArtifactStore extends CloseableSupport implements ArtifactStore
             boolean allowRedeploy,
             List<ChecksumAlgorithmFactory> checksumAlgorithmFactories,
             List<String> omitChecksumsForExtensions,
+            Artifact originProjectArtifact, // nullable
             Path basedir) {
         this.name = requireNonNull(name);
         this.template = requireNonNull(template);
@@ -71,6 +73,7 @@ public class PathArtifactStore extends CloseableSupport implements ArtifactStore
         this.allowRedeploy = allowRedeploy;
         this.checksumAlgorithmFactories = requireNonNull(checksumAlgorithmFactories);
         this.omitChecksumsForExtensions = requireNonNull(omitChecksumsForExtensions);
+        this.originProjectArtifact = originProjectArtifact;
         this.basedir = requireNonNull(basedir);
         this.storeLayout = new DefaultLayout();
     }
@@ -113,6 +116,11 @@ public class PathArtifactStore extends CloseableSupport implements ArtifactStore
     @Override
     public List<String> omitChecksumsForExtensions() {
         return omitChecksumsForExtensions;
+    }
+
+    @Override
+    public Optional<Artifact> originProjectArtifact() {
+        return Optional.ofNullable(originProjectArtifact);
     }
 
     @Override
@@ -284,14 +292,17 @@ public class PathArtifactStore extends CloseableSupport implements ArtifactStore
 
     @Override
     public String toString() {
+        String origin =
+                originProjectArtifact == null ? "" : " from " + ArtifactIdUtils.toId(originProjectArtifact) + " ";
         if (closed.get()) {
             return String.format(
-                    "%s (%s, %s, %s, closed)",
-                    name(), created(), repositoryMode().name(), template.name());
+                    "%s%s(%s, %s, %s, closed)",
+                    name(), origin, created(), repositoryMode().name(), template.name());
         } else {
             return String.format(
-                    "%s (%s, %s, %s, %s artifacts)",
+                    "%s%s(%s, %s, %s, %s artifacts)",
                     name(),
+                    origin,
                     created(),
                     repositoryMode().name(),
                     template.name(),

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStore.java
@@ -59,6 +59,11 @@ public interface ArtifactStore extends Closeable {
     List<String> omitChecksumsForExtensions();
 
     /**
+     * The origin project artifact, that was used to create this store instance, if applicable.
+     */
+    Optional<Artifact> originProjectArtifact();
+
+    /**
      * Index of artifacts in this store (except checksums), never {@code null}.
      */
     Collection<Artifact> artifacts();

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreManager.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.eclipse.aether.artifact.Artifact;
 
 public interface ArtifactStoreManager {
     /**
@@ -42,9 +43,10 @@ public interface ArtifactStoreManager {
     Collection<ArtifactStoreTemplate> listTemplates();
 
     /**
-     * Creates store based on template.
+     * Creates store based on template. Optionally, the "origin project" may be given, or {@code null}.
      */
-    ArtifactStore createArtifactStore(ArtifactStoreTemplate template) throws IOException;
+    ArtifactStore createArtifactStore(ArtifactStoreTemplate template, Artifact originProjectArtifact)
+            throws IOException;
 
     /**
      * Fully deletes store.

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -16,7 +16,6 @@ import com.github.mizosoft.methanol.MultipartBodyPublisher;
 import com.github.mizosoft.methanol.MutableRequest;
 import eu.maveniverse.maven.njord.shared.NjordUtils;
 import eu.maveniverse.maven.njord.shared.Session;
-import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.impl.store.ArtifactStoreDeployer;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherSupport;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
@@ -34,6 +33,7 @@ import java.util.Objects;
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.ConfigUtils;
@@ -79,11 +79,10 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 String bundleName = bundle.getFileName().toString();
                 if (publisherConfig.bundleName().isPresent()) {
                     bundleName = publisherConfig.bundleName().orElseThrow();
-                } else if (session.config().currentProject().isPresent()) {
-                    SessionConfig.CurrentProject cp =
-                            session.config().currentProject().orElseThrow();
-                    bundleName =
-                            cp.artifact().getArtifactId() + "-" + cp.artifact().getVersion();
+                } else if (artifactStore.originProjectArtifact().isPresent()) {
+                    Artifact originProjectArtifact =
+                            artifactStore.originProjectArtifact().orElseThrow();
+                    bundleName = originProjectArtifact.getArtifactId() + "-" + originProjectArtifact.getVersion();
                 }
 
                 // build auth token


### PR DESCRIPTION
This did not affect users using "auto publish" feature, but did affect projects that did two step: stage then publish.

Sonatype CP publisher used "current project" A-V to name the bundle, but thid was wrong in latter case: as staged project may be 1.9.0 while current may be 2.0.0-SNAPSHOT.

Now the store "memoizes" and carries over the "origin project artifact" (TLP).

Fixes #86