### PR TITLE
Fix missing authz when publishing to a Maven repository using deployer

### DIFF
--- a/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisher.java
+++ b/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisher.java
@@ -49,7 +49,7 @@ public class DeployPublisher extends ArtifactStorePublisherSupport {
         RemoteRepository authSource = repositorySystem.newDeploymentRepository(
                 session.config().session(),
                 session.artifactPublisherRedirector().getAuthRepositoryId(repository));
-        if (!Objects.equals(repository.getId(), authSource.getId())) {
+        if (Objects.equals(repository.getId(), authSource.getId())) {
             repository = new RemoteRepository.Builder(repository)
                     .setAuthentication(authSource.getAuthentication())
                     .setProxy(repository.getProxy())


### PR DESCRIPTION
when using something such:
```
mvn njord:publish  -Ddrop=false -Dpublisher=deploy -DaltDeploymentRepository=id-from-settings:http://foo.bar.com/beer
```
The authz for server `id-from-settings` are not used