### PR TITLE
Downgrade to Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Documentation available: https://maveniverse.eu/docs/njord/
 
 Requirements:
-* Java 11+
+* Java 8+
 * Maven 3.9+ (tested with 3.9.9 and 4.0.0-rc-3)
 
 Note: this code is Proof of Concept, with a lot of To-Be-Done parts and intentionally simple as possible.

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.shared;
 
 import static java.util.Objects.requireNonNull;
 
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import eu.maveniverse.maven.shared.core.maven.MavenUtils;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -278,8 +280,8 @@ public interface SessionConfig {
         requireNonNull(project);
         if (!"org.apache.maven:standalone-pom".equals(project.getGroupId() + ":" + project.getArtifactId())) {
             final Artifact artifact = RepositoryUtils.toArtifact(project.getArtifact());
-            final Map<String, String> properties = Map.copyOf(MavenUtils.toMap(project.getProperties()));
-            final List<RemoteRepository> remoteRepositories = List.copyOf(project.getRemoteProjectRepositories());
+            final Map<String, String> properties = J8Utils.copyOf(MavenUtils.toMap(project.getProperties()));
+            final List<RemoteRepository> remoteRepositories = J8Utils.copyOf(project.getRemoteProjectRepositories());
             final Map<RepositoryMode, RemoteRepository> dmr = new HashMap<>();
             if (project.getDistributionManagement() != null) {
                 DeploymentRepository dr = project.getDistributionManagement().getRepository();
@@ -299,7 +301,7 @@ public interface SessionConfig {
                                     .build());
                 }
             }
-            final Map<RepositoryMode, RemoteRepository> distributionManagementRepositories = Map.copyOf(dmr);
+            final Map<RepositoryMode, RemoteRepository> distributionManagementRepositories = J8Utils.copyOf(dmr);
             return new SessionConfig.CurrentProject() {
                 @Override
                 public Artifact artifact() {
@@ -337,7 +339,7 @@ public interface SessionConfig {
                 MavenUtils.discoverArtifactVersion(
                         SessionConfig.class.getClassLoader(), "eu.maveniverse.maven.njord", "core", null),
                 discoverBaseDirectory(),
-                Path.of("njord.properties"),
+                Paths.get("njord.properties"),
                 session.getSystemProperties(),
                 session.getUserProperties(),
                 session,
@@ -493,9 +495,9 @@ public interface SessionConfig {
                     }
                 }
 
-                this.njordProperties = Map.copyOf(MavenUtils.toMap(properties));
-                this.userProperties = Map.copyOf(requireNonNull(userProperties, "userProperties"));
-                this.systemProperties = Map.copyOf(requireNonNull(systemProperties, "systemProperties"));
+                this.njordProperties = J8Utils.copyOf(MavenUtils.toMap(properties));
+                this.userProperties = J8Utils.copyOf(requireNonNull(userProperties, "userProperties"));
+                this.systemProperties = J8Utils.copyOf(requireNonNull(systemProperties, "systemProperties"));
 
                 Map<String, String> ep = new HashMap<>(systemProperties);
                 ep.putAll(njordProperties);
@@ -503,15 +505,15 @@ public interface SessionConfig {
                     properties.putAll(currentProject.projectProperties());
                 }
                 properties.putAll(userProperties);
-                this.effectiveProperties = Map.copyOf(ep);
+                this.effectiveProperties = J8Utils.copyOf(ep);
 
                 this.session = requireNonNull(session);
-                this.remoteRepositories = List.copyOf(requireNonNull(remoteRepositories));
+                this.remoteRepositories = J8Utils.copyOf(requireNonNull(remoteRepositories));
                 ArrayList<RemoteRepository> arr = new ArrayList<>(remoteRepositories);
                 if (currentProject != null) {
                     arr.addAll(currentProject.remoteRepositories());
                 }
-                this.allRemoteRepositories = List.copyOf(arr);
+                this.allRemoteRepositories = J8Utils.copyOf(arr);
 
                 String autoPrefixString = effectiveProperties.get(CONFIG_AUTO_PREFIX);
                 if (autoPrefixString == null && currentProject != null) {
@@ -635,7 +637,7 @@ public interface SessionConfig {
         if (basedir == null) {
             return getCanonicalPath(discoverUserHomeDirectory().resolve(".njord"));
         }
-        return getCanonicalPath(Path.of(System.getProperty("user.dir")).resolve(basedir));
+        return getCanonicalPath(Paths.get(System.getProperty("user.dir")).resolve(basedir));
     }
 
     static Path discoverUserHomeDirectory() {
@@ -643,7 +645,7 @@ public interface SessionConfig {
         if (userHome == null) {
             throw new IllegalStateException("requires user.home Java System Property set");
         }
-        return getCanonicalPath(Path.of(userHome));
+        return getCanonicalPath(Paths.get(userHome));
     }
 
     static Path getCanonicalPath(Path path) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
@@ -138,7 +138,7 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
                     // empty -> default IF project is available
                     if (config.currentProject().isPresent()) {
                         return internalArtifactStoreManager.defaultTemplate(
-                                config.currentProject().orElseThrow().repositoryMode());
+                                config.currentProject().orElseThrow(J8Utils.OET).repositoryMode());
                     } else {
                         throw new IllegalStateException(
                                 "No project present, cannot deduce repository mode: specify template explicitly as `njord:template:<TEMPLATE>`");
@@ -154,7 +154,7 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
                 // store:xxx
                 try (ArtifactStore artifactStore = internalArtifactStoreManager
                         .selectArtifactStore(uri.substring(6))
-                        .orElseThrow(() -> new IllegalArgumentException("Unknown store"))) {
+                        .orElseThrow(J8Utils.OET)) {
                     return artifactStore.template();
                 }
             } else {
@@ -179,7 +179,7 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
                         if (config.currentProject().isPresent()) {
                             artifactStoreName = createUsingTemplate(internalArtifactStoreManager
                                     .defaultTemplate(config.currentProject()
-                                            .orElseThrow()
+                                            .orElseThrow(J8Utils.OET)
                                             .repositoryMode())
                                     .name());
                         } else {
@@ -205,9 +205,7 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
             }
         });
         try {
-            return internalArtifactStoreManager
-                    .selectArtifactStore(storeName)
-                    .orElseThrow(() -> new IllegalArgumentException("No such store: " + storeName));
+            return internalArtifactStoreManager.selectArtifactStore(storeName).orElseThrow(J8Utils.OET);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -222,7 +220,7 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
         } else {
             ArtifactStoreTemplate template = templates.get(0);
             if (config.prefix().isPresent()) {
-                template = template.withPrefix(config.prefix().orElseThrow());
+                template = template.withPrefix(config.prefix().orElseThrow(J8Utils.OET));
             }
             return template;
         }
@@ -232,7 +230,7 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
         try (ArtifactStore artifactStore = internalArtifactStoreManager.createArtifactStore(
                 selectTemplate(templateName),
                 config.currentProject().isPresent()
-                        ? config.currentProject().orElseThrow().artifact()
+                        ? config.currentProject().orElseThrow(J8Utils.OET).artifact()
                         : null)) {
             return artifactStore.name();
         }
@@ -251,16 +249,16 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
         AtomicInteger result = new AtomicInteger(published);
         Optional<String> pno = artifactPublisherRedirector.getArtifactStorePublisherName();
         if (pno.isPresent()) {
-            String publisherName = pno.orElseThrow();
+            String publisherName = pno.orElseThrow(J8Utils.OET);
             Optional<ArtifactStorePublisher> po = selectArtifactStorePublisher(publisherName);
             if (po.isPresent()) {
-                ArtifactStorePublisher p = po.orElseThrow();
+                ArtifactStorePublisher p = po.orElseThrow(J8Utils.OET);
                 sessionBoundStore.values().forEach(n -> {
                     try {
                         logger.info("Publishing {} with {}", n, publisherName);
                         try (ArtifactStore as = internalArtifactStoreManager
                                 .selectArtifactStore(n)
-                                .orElseThrow()) {
+                                .orElseThrow(J8Utils.OET)) {
                             p.publish(as);
                             result.addAndGet(1);
                         }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/J8Utils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/J8Utils.java
@@ -19,11 +19,20 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+/**
+ * A bunch of Java 8 utils that in fact exists in higher Java versions.
+ */
 public final class J8Utils {
     private J8Utils() {}
 
+    /**
+     * Java 8: no <code>Optional.getOrElseThrow()</code> method.
+     */
     public static Supplier<IllegalStateException> OET = () -> new IllegalStateException("No value present");
 
+    /**
+     * Java 8: {@code Map.of("create", "true")}.
+     */
     public static Map<String, String> zipFsCreate(boolean create) {
         HashMap<String, String> map = new HashMap<>();
         map.put("create", Boolean.toString(create));
@@ -32,7 +41,11 @@ public final class J8Utils {
 
     private static final int DEFAULT_BUFFER_SIZE = 16384;
 
+    /**
+     * Java 8: copy of Java 11 <code>InputStream.transferTo(OutputStream)</code>.
+     */
     public static long transferTo(InputStream in, OutputStream out) throws IOException {
+        Objects.requireNonNull(in, "in");
         Objects.requireNonNull(out, "out");
         long transferred = 0;
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
@@ -50,10 +63,16 @@ public final class J8Utils {
         return transferred;
     }
 
+    /**
+     * Java 8: Map.copyOf()
+     */
     public static <K, V> Map<K, V> copyOf(Map<K, V> map) {
         return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
+    /**
+     * Java 8: List.copyOf()
+     */
     public static <E1, E2 extends E1> List<E1> copyOf(Collection<E2> list) {
         return Collections.unmodifiableList(new ArrayList<>(list));
     }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/J8Utils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/J8Utils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.njord.shared.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public final class J8Utils {
+    private J8Utils() {}
+
+    public static Supplier<IllegalStateException> OET = () -> new IllegalStateException("No value present");
+
+    public static Map<String, String> zipFsCreate(boolean create) {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("create", Boolean.toString(create));
+        return map;
+    }
+
+    private static final int DEFAULT_BUFFER_SIZE = 16384;
+
+    public static long transferTo(InputStream in, OutputStream out) throws IOException {
+        Objects.requireNonNull(out, "out");
+        long transferred = 0;
+        byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+        int read;
+        while ((read = in.read(buffer, 0, DEFAULT_BUFFER_SIZE)) >= 0) {
+            out.write(buffer, 0, read);
+            if (transferred < Long.MAX_VALUE) {
+                try {
+                    transferred = Math.addExact(transferred, read);
+                } catch (ArithmeticException ignore) {
+                    transferred = Long.MAX_VALUE;
+                }
+            }
+        }
+        return transferred;
+    }
+
+    public static <K, V> Map<K, V> copyOf(Map<K, V> map) {
+        return Collections.unmodifiableMap(new HashMap<>(map));
+    }
+
+    public static <E1, E2 extends E1> List<E1> copyOf(Collection<E2> list) {
+        return Collections.unmodifiableList(new ArrayList<>(list));
+    }
+}

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/J8Utils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/J8Utils.java
@@ -31,7 +31,7 @@ public final class J8Utils {
     public static Supplier<IllegalStateException> OET = () -> new IllegalStateException("No value present");
 
     /**
-     * Java 8: {@code Map.of("create", "true")}.
+     * Java 8: <code>Map.of("create", "true")</code>.
      */
     public static Map<String, String> zipFsCreate(boolean create) {
         HashMap<String, String> map = new HashMap<>();
@@ -64,14 +64,14 @@ public final class J8Utils {
     }
 
     /**
-     * Java 8: Map.copyOf()
+     * Java 8: <code>Map.copyOf(Map)</code>
      */
     public static <K, V> Map<K, V> copyOf(Map<K, V> map) {
         return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     /**
-     * Java 8: List.copyOf()
+     * Java 8: <code>List.copyOf(Collection)</code>
      */
     public static <E1, E2 extends E1> List<E1> copyOf(Collection<E2> list) {
         return Collections.unmodifiableList(new ArrayList<>(list));

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/comparator/ArtifactStoreComparatorSupport.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/comparator/ArtifactStoreComparatorSupport.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.impl.comparator;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreComparator;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
@@ -120,17 +121,17 @@ public abstract class ArtifactStoreComparatorSupport extends ComponentSupport im
 
         @Override
         public Collection<String> equalities() {
-            return List.copyOf(equalities);
+            return J8Utils.copyOf(equalities);
         }
 
         @Override
         public Collection<String> differences() {
-            return List.copyOf(differences);
+            return J8Utils.copyOf(differences);
         }
 
         @Override
         public Collection<ComparisonResult> children() {
-            return List.copyOf(children.values());
+            return J8Utils.copyOf(children.values());
         }
 
         @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/comparator/BitwiseArtifactStoreComparator.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/comparator/BitwiseArtifactStoreComparator.java
@@ -13,6 +13,7 @@ import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.aether.artifact.Artifact;
@@ -48,7 +49,7 @@ public class BitwiseArtifactStoreComparator extends ArtifactStoreComparatorSuppo
         Collection<Artifact> a2artifacts = a2.artifacts();
 
         List<ChecksumAlgorithmFactory> checksumAlgorithmFactories =
-                checksumAlgorithmFactorySelector.selectList(List.of(SHA1));
+                checksumAlgorithmFactorySelector.selectList(Collections.singletonList(SHA1));
 
         ComparisonContext context = comparisonContext.child("Bitwise comparison");
         for (Artifact artifact : extractIndex(a1)) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirector.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactPublisherRedirector;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
@@ -38,7 +39,8 @@ public class DefaultArtifactPublisherRedirector extends ComponentSupport impleme
         if (!url.startsWith(SessionConfig.NAME + ":")
                 && session.config().currentProject().isPresent()) {
             return getRepositoryUrl(
-                    repository, session.config().currentProject().orElseThrow().repositoryMode());
+                    repository,
+                    session.config().currentProject().orElseThrow(J8Utils.OET).repositoryMode());
         }
         return url;
     }
@@ -51,7 +53,7 @@ public class DefaultArtifactPublisherRedirector extends ComponentSupport impleme
         String url = repository.getUrl();
         Optional<Map<String, String>> sco = session.config().serviceConfiguration(repository.getId());
         if (!url.startsWith(SessionConfig.NAME + ":") && sco.isPresent()) {
-            Map<String, String> config = sco.orElseThrow();
+            Map<String, String> config = sco.orElseThrow(J8Utils.OET);
             String redirectUrl;
             switch (repositoryMode) {
                 case RELEASE:
@@ -80,7 +82,7 @@ public class DefaultArtifactPublisherRedirector extends ComponentSupport impleme
             authSourcesVisited.add(authSource.getId());
             Optional<Map<String, String>> config = session.config().serviceConfiguration(authSource.getId());
             while (config.isPresent()) {
-                String authRedirect = config.orElseThrow().get(SessionConfig.CONFIG_AUTH_REDIRECT);
+                String authRedirect = config.orElseThrow(J8Utils.OET).get(SessionConfig.CONFIG_AUTH_REDIRECT);
                 if (authRedirect != null) {
                     logger.debug("Following auth redirect {} -> {}", authSource.getId(), authRedirect);
                     authSource = new RemoteRepository.Builder(
@@ -134,14 +136,17 @@ public class DefaultArtifactPublisherRedirector extends ComponentSupport impleme
         if (session.config().currentProject().isPresent()) {
             RemoteRepository distributionRepository = session.config()
                     .currentProject()
-                    .orElseThrow()
+                    .orElseThrow(J8Utils.OET)
                     .distributionManagementRepositories()
-                    .get(session.config().currentProject().orElseThrow().repositoryMode());
+                    .get(session.config()
+                            .currentProject()
+                            .orElseThrow(J8Utils.OET)
+                            .repositoryMode());
             if (distributionRepository != null) {
                 Optional<Map<String, String>> sco =
                         session.config().serviceConfiguration(distributionRepository.getId());
                 if (sco.isPresent()) {
-                    String publisher = sco.orElseThrow().get(SessionConfig.CONFIG_PUBLISHER);
+                    String publisher = sco.orElseThrow(J8Utils.OET).get(SessionConfig.CONFIG_PUBLISHER);
                     if (publisher != null) {
                         return Optional.of(publisher);
                     }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactStoreValidator.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactStoreValidator.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.impl.publisher;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreValidator;
 import eu.maveniverse.maven.njord.shared.publisher.spi.BulkValidator;
 import eu.maveniverse.maven.njord.shared.publisher.spi.BulkValidatorFactory;
@@ -21,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.List;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 import org.slf4j.Logger;
@@ -128,22 +128,22 @@ public class DefaultArtifactStoreValidator implements ArtifactStoreValidator {
 
         @Override
         public Collection<String> info() {
-            return List.copyOf(info);
+            return J8Utils.copyOf(info);
         }
 
         @Override
         public Collection<String> warning() {
-            return List.copyOf(warnings);
+            return J8Utils.copyOf(warnings);
         }
 
         @Override
         public Collection<String> error() {
-            return List.copyOf(errors);
+            return J8Utils.copyOf(errors);
         }
 
         @Override
         public Collection<ValidationResult> children() {
-            return List.copyOf(children.values());
+            return J8Utils.copyOf(children.values());
         }
 
         @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/ArtifactChecksumValidator.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/ArtifactChecksumValidator.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.shared.impl.publisher.basic;
 
 import static java.util.Objects.requireNonNull;
 
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.impl.publisher.ValidatorSupport;
 import eu.maveniverse.maven.njord.shared.publisher.spi.ValidationContext;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
@@ -76,10 +77,10 @@ public class ArtifactChecksumValidator extends ValidatorSupport {
             Optional<InputStream> co = artifactStore.artifactContent(checksumArtifact);
             if (co.isPresent()) {
                 String deployed;
-                try (InputStream in = co.orElseThrow()) {
+                try (InputStream in = co.orElseThrow(J8Utils.OET)) {
                     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                    in.transferTo(bos);
-                    deployed = bos.toString(StandardCharsets.UTF_8);
+                    J8Utils.transferTo(in, bos);
+                    deployed = new String(bos.toByteArray(), StandardCharsets.UTF_8);
                 }
                 if (Objects.equals(calculated, deployed)) {
                     algOk.add(algorithmFactory.getName());

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomCoordinatesValidatorFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomCoordinatesValidatorFactory.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.shared.impl.publisher.basic;
 
 import static java.util.Objects.requireNonNull;
 
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.impl.ModelProvider;
 import eu.maveniverse.maven.njord.shared.impl.publisher.ValidatorSupport;
 import eu.maveniverse.maven.njord.shared.publisher.spi.ValidationContext;
@@ -50,7 +51,7 @@ public class PomCoordinatesValidatorFactory extends ValidatorSupport {
             remoteRepositories.add(artifactStore.storeRemoteRepository());
             Optional<Model> mo = modelProvider.readEffectiveModel(session, artifact, remoteRepositories);
             if (mo.isPresent()) {
-                Model m = mo.orElseThrow();
+                Model m = mo.orElseThrow(J8Utils.OET);
                 if (Objects.equals(artifact.getGroupId(), m.getGroupId())
                         && Objects.equals(artifact.getArtifactId(), m.getArtifactId())
                         && Objects.equals(artifact.getBaseVersion(), m.getVersion())) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/PomProjectValidatorFactory.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.shared.impl.publisher.basic;
 
 import static java.util.Objects.requireNonNull;
 
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.impl.ModelProvider;
 import eu.maveniverse.maven.njord.shared.impl.publisher.ValidatorSupport;
 import eu.maveniverse.maven.njord.shared.publisher.spi.ValidationContext;
@@ -52,7 +53,7 @@ public class PomProjectValidatorFactory extends ValidatorSupport {
             remoteRepositories.add(artifactStore.storeRemoteRepository());
             Optional<Model> mo = modelProvider.readEffectiveModel(session, artifact, remoteRepositories);
             if (mo.isPresent()) {
-                Model m = mo.orElseThrow();
+                Model m = mo.orElseThrow(J8Utils.OET);
                 if (!nullOrBlank(m.getName())) {
                     collector.addInfo("VALID project/name");
                 } else {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/signature/ArtifactSignatureValidator.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/signature/ArtifactSignatureValidator.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.njord.shared.impl.publisher.signature;
 
 import static java.util.Objects.requireNonNull;
 
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.impl.publisher.ValidatorSupport;
 import eu.maveniverse.maven.njord.shared.publisher.spi.ValidationContext;
 import eu.maveniverse.maven.njord.shared.publisher.spi.signature.SignatureType;
@@ -80,9 +81,9 @@ public class ArtifactSignatureValidator extends ValidatorSupport {
                 } else {
                     for (SignatureValidator signatureValidator : typeSignatureValidator) {
                         try (InputStream artifactContent =
-                                        artifactStore.artifactContent(artifact).orElseThrow();
+                                        artifactStore.artifactContent(artifact).orElseThrow(J8Utils.OET);
                                 InputStream signatureContent =
-                                        artifactStore.artifactContent(signature).orElseThrow()) {
+                                        artifactStore.artifactContent(signature).orElseThrow(J8Utils.OET)) {
                             SignatureValidator.Outcome outcome = signatureValidator.verifySignature(
                                     artifactStore,
                                     artifact,

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStoreMerger.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStoreMerger.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.impl.store;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreMerger;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
@@ -83,12 +84,12 @@ public class DefaultArtifactStoreMerger extends ComponentSupport implements Arti
 
                 // must be present in source; comes from it
                 contentOptional = source.artifactContent(sourceArtifact);
-                try (InputStream content = contentOptional.orElseThrow()) {
+                try (InputStream content = contentOptional.orElseThrow(J8Utils.OET)) {
                     sourceSha1 = checksumSha1(content);
                 }
                 // must be present in target; it told us so
                 contentOptional = target.artifactContent(sourceArtifact);
-                try (InputStream content = contentOptional.orElseThrow()) {
+                try (InputStream content = contentOptional.orElseThrow(J8Utils.OET)) {
                     targetSha1 = checksumSha1(content);
                 }
 

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStoreWriter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStoreWriter.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.impl.store;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreWriter;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
@@ -19,7 +20,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 
 public class DefaultArtifactStoreWriter extends ComponentSupport implements ArtifactStoreWriter {
     private final SessionConfig sessionConfig;
@@ -55,7 +55,7 @@ public class DefaultArtifactStoreWriter extends ComponentSupport implements Arti
             throw new IOException("Exporting to existing bundle ZIP not supported");
         }
         try (FileSystem fs =
-                FileSystems.newFileSystem(URI.create("jar:" + bundleFile.toUri()), Map.of("create", "true"), null)) {
+                FileSystems.newFileSystem(URI.create("jar:" + bundleFile.toUri()), J8Utils.zipFsCreate(true), null)) {
             Path root = fs.getPath("/");
             artifactStore.writeTo(root);
         }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisherSupport.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisherSupport.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.publisher;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
@@ -96,7 +97,8 @@ public abstract class ArtifactStorePublisherSupport extends ComponentSupport imp
             throws IOException {
         Optional<ArtifactStoreValidator> vo = validatorFor(artifactStore);
         if (vo.isPresent()) {
-            ArtifactStoreValidator.ValidationResult vr = vo.orElseThrow().validate(artifactStore);
+            ArtifactStoreValidator.ValidationResult vr =
+                    vo.orElseThrow(J8Utils.OET).validate(artifactStore);
             return Optional.of(vr);
         } else {
             return Optional.empty();

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/PublisherConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/PublisherConfig.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.shared.publisher;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import java.util.Map;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -53,7 +54,7 @@ public class PublisherConfig {
         if (sessionConfig.currentProject().isPresent()) {
             RemoteRepository repository = sessionConfig
                     .currentProject()
-                    .orElseThrow()
+                    .orElseThrow(J8Utils.OET)
                     .distributionManagementRepositories()
                     .get(mode);
             if (repository != null) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
@@ -22,7 +22,7 @@ public interface ArtifactStoreTemplate {
     List<String> DEFAULT_CHECKSUM_ALGORITHMS = Collections.unmodifiableList(Arrays.asList("SHA-1", "MD5"));
 
     /**
-     * The default checksum algorithms.
+     * The strong checksum algorithms (SCA).
      */
     List<String> STRONG_CHECKSUM_ALGORITHMS =
             Collections.unmodifiableList(Arrays.asList("SHA-512", "SHA-256", "SHA-1", "MD5"));

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreTemplate.java
@@ -9,6 +9,8 @@ package eu.maveniverse.maven.njord.shared.store;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,17 +19,19 @@ public interface ArtifactStoreTemplate {
     /**
      * The default checksum algorithms.
      */
-    List<String> DEFAULT_CHECKSUM_ALGORITHMS = List.of("SHA-1", "MD5");
+    List<String> DEFAULT_CHECKSUM_ALGORITHMS = Collections.unmodifiableList(Arrays.asList("SHA-1", "MD5"));
 
     /**
      * The default checksum algorithms.
      */
-    List<String> STRONG_CHECKSUM_ALGORITHMS = List.of("SHA-512", "SHA-256", "SHA-1", "MD5");
+    List<String> STRONG_CHECKSUM_ALGORITHMS =
+            Collections.unmodifiableList(Arrays.asList("SHA-512", "SHA-256", "SHA-1", "MD5"));
 
     /**
      * The default extensions to omit checksums for.
      */
-    List<String> DEFAULT_OMIT_CHECKSUMS_FOR_EXTENSIONS = List.of(".asc", ".sigstore", ".sigstore.json");
+    List<String> DEFAULT_OMIT_CHECKSUMS_FOR_EXTENSIONS =
+            Collections.unmodifiableList(Arrays.asList(".asc", ".sigstore", ".sigstore.json"));
 
     /**
      * Template name.

--- a/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordRepositoryConnectorFactory.java
+++ b/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordRepositoryConnectorFactory.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.NjordUtils;
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.util.Map;
 import java.util.Optional;
@@ -54,11 +55,8 @@ public class NjordRepositoryConnectorFactory implements RepositoryConnectorFacto
         boolean connectorSkip = ConfigUtils.getBoolean(session, false, NjordUtils.RESOLVER_SESSION_CONNECTOR_SKIP);
         if (!connectorSkip) {
             Optional<Session> nso = NjordUtils.mayGetNjordSession(session);
-            if (nso.isPresent()
-                    && nso.orElseThrow(() -> new IllegalStateException("Value unavailable"))
-                            .config()
-                            .enabled()) {
-                Session ns = nso.orElseThrow(() -> new IllegalStateException("Value unavailable"));
+            if (nso.isPresent() && nso.orElseThrow(J8Utils.OET).config().enabled()) {
+                Session ns = nso.orElseThrow(J8Utils.OET);
                 String url = ns.artifactPublisherRedirector().getRepositoryUrl(repository);
                 if (url != null && url.startsWith(NAME + ":")) {
                     RepositoryConnectorFactory basicRepositoryConnectorFactory = requireNonNull(

--- a/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
@@ -13,6 +13,7 @@ import eu.maveniverse.maven.njord.shared.NjordUtils;
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.SessionFactory;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -66,7 +67,7 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
         try {
             Optional<Session> ns = NjordUtils.mayGetNjordSession(session.getRepositorySession());
             if (ns.isPresent()) {
-                Session njordSession = ns.orElseThrow(() -> new IllegalStateException("Value unavailable"));
+                Session njordSession = ns.orElseThrow(J8Utils.OET);
                 if (njordSession.config().enabled()) {
                     if (session.getResult().hasExceptions()) {
                         int dropped = njordSession.dropSessionArtifactStores();

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/CompareMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/CompareMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreComparator;
 import java.io.IOException;
@@ -48,20 +49,20 @@ public class CompareMojo extends NjordMojoSupport {
     @Override
     protected void doWithSession(Session ns) throws IOException, MojoFailureException {
         Optional<ArtifactStore> store1Optional = ns.artifactStoreManager().selectArtifactStore(store1);
-        if (store1Optional.isEmpty()) {
+        if (!store1Optional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", store1);
             return;
         }
         Optional<ArtifactStore> store2Optional = ns.artifactStoreManager().selectArtifactStore(store2);
-        if (store2Optional.isEmpty()) {
+        if (!store2Optional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", store2);
             return;
         }
         Optional<ArtifactStoreComparator> po = ns.selectArtifactStoreComparator(comparator);
         if (po.isPresent()) {
-            ArtifactStoreComparator p = po.orElseThrow();
-            try (ArtifactStore one = store1Optional.orElseThrow();
-                    ArtifactStore two = store2Optional.orElseThrow()) {
+            ArtifactStoreComparator p = po.orElseThrow(J8Utils.OET);
+            try (ArtifactStore one = store1Optional.orElseThrow(J8Utils.OET);
+                    ArtifactStore two = store2Optional.orElseThrow(J8Utils.OET)) {
                 ArtifactStoreComparator.ComparisonResult vr = p.compare(one, two);
                 if (details) {
                     logger.info("Comparison results for {} vs {}", store1, store2);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ExportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ExportMojo.java
@@ -9,9 +9,11 @@ package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -39,9 +41,9 @@ public class ExportMojo extends NjordMojoSupport {
     protected void doWithSession(Session ns) throws IOException, MojoExecutionException {
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
         if (storeOptional.isPresent()) {
-            Path targetPath = SessionConfig.getCanonicalPath(Path.of(path).toAbsolutePath());
+            Path targetPath = SessionConfig.getCanonicalPath(Paths.get(path).toAbsolutePath());
             logger.info("Exporting store {} to {}", store, targetPath);
-            Path bundle = ns.artifactStoreManager().exportTo(storeOptional.orElseThrow(), targetPath);
+            Path bundle = ns.artifactStoreManager().exportTo(storeOptional.orElseThrow(J8Utils.OET), targetPath);
             logger.info("Exported to " + bundle);
         } else {
             logger.warn("ArtifactStore with given name not found");

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ImportAllMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ImportAllMojo.java
@@ -13,6 +13,7 @@ import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -33,7 +34,7 @@ public class ImportAllMojo extends NjordMojoSupport {
 
     @Override
     protected void doWithSession(Session ns) throws IOException, MojoExecutionException {
-        Path sourceDirectory = SessionConfig.getCanonicalPath(Path.of(dir).toAbsolutePath());
+        Path sourceDirectory = SessionConfig.getCanonicalPath(Paths.get(dir).toAbsolutePath());
         if (!Files.isDirectory(sourceDirectory)) {
             throw new MojoExecutionException("Import directory does not exist");
         }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ImportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ImportMojo.java
@@ -13,6 +13,7 @@ import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -30,7 +31,7 @@ public class ImportMojo extends NjordMojoSupport {
 
     @Override
     protected void doWithSession(Session ns) throws IOException, MojoExecutionException {
-        Path source = SessionConfig.getCanonicalPath(Path.of(file).toAbsolutePath());
+        Path source = SessionConfig.getCanonicalPath(Paths.get(file).toAbsolutePath());
         if (!Files.exists(source)) {
             throw new MojoExecutionException("Import file not found: " + file);
         }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListContentMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListContentMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.util.Optional;
@@ -32,7 +33,7 @@ public class ListContentMojo extends NjordMojoSupport {
     protected void doWithSession(Session ns) throws IOException {
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
         if (storeOptional.isPresent()) {
-            try (ArtifactStore store = storeOptional.orElseThrow()) {
+            try (ArtifactStore store = storeOptional.orElseThrow(J8Utils.OET)) {
                 logger.info("List contents of ArtifactStore {}", store);
                 AtomicInteger counter = new AtomicInteger();
                 for (Artifact artifact : store.artifacts()) {

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ListMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.util.List;
@@ -26,7 +27,7 @@ public class ListMojo extends NjordMojoSupport {
         for (String storeName : storeNames) {
             Optional<ArtifactStore> aso = ns.artifactStoreManager().selectArtifactStore(storeName);
             if (aso.isPresent()) {
-                try (ArtifactStore store = aso.orElseThrow()) {
+                try (ArtifactStore store = aso.orElseThrow(J8Utils.OET)) {
                     logger.info("- " + store);
                 }
             }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/MergeAllMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/MergeAllMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreMerger;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
@@ -53,7 +54,7 @@ public class MergeAllMojo extends NjordMojoSupport {
             Optional<ArtifactStore> so = ns.artifactStoreManager().selectArtifactStore(name);
             if (so.isPresent()) {
                 names.add(name);
-                try (ArtifactStore store = so.orElseThrow()) {
+                try (ArtifactStore store = so.orElseThrow(J8Utils.OET)) {
                     if (template == null) {
                         template = store.template();
                     } else if (!template.equals(store.template())) {
@@ -82,10 +83,10 @@ public class MergeAllMojo extends NjordMojoSupport {
         for (String name : names) {
             Optional<ArtifactStore> so = ns.artifactStoreManager().selectArtifactStore(name);
             if (so.isPresent()) {
-                try (ArtifactStore source = so.orElseThrow();
+                try (ArtifactStore source = so.orElseThrow(J8Utils.OET);
                         ArtifactStore target = ns.artifactStoreManager()
                                 .selectArtifactStore(targetName)
-                                .orElseThrow()) {
+                                .orElseThrow(J8Utils.OET)) {
                     merger.merge(source, target);
                 }
                 logger.info("Dropping {}", name);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/MergeMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/MergeMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.util.Optional;
@@ -41,16 +42,16 @@ public class MergeMojo extends NjordMojoSupport {
     protected void doWithSession(Session ns) throws IOException {
         Optional<ArtifactStore> fromOptional = ns.artifactStoreManager().selectArtifactStore(from);
         Optional<ArtifactStore> toOptional = ns.artifactStoreManager().selectArtifactStore(to);
-        if (fromOptional.isEmpty()) {
+        if (!fromOptional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", from);
             return;
         }
-        if (toOptional.isEmpty()) {
+        if (!toOptional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", to);
             return;
         }
 
-        ns.artifactStoreMerger().merge(fromOptional.orElseThrow(), toOptional.orElseThrow());
+        ns.artifactStoreMerger().merge(fromOptional.orElseThrow(J8Utils.OET), toOptional.orElseThrow(J8Utils.OET));
         if (drop) {
             logger.info("Dropping {}", from);
             ns.artifactStoreManager().dropArtifactStore(from);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
@@ -11,6 +11,7 @@ import eu.maveniverse.maven.njord.shared.NjordUtils;
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.SessionFactory;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
 import eu.maveniverse.maven.njord.shared.publisher.spi.signature.SignatureType;
@@ -38,10 +39,10 @@ public abstract class NjordMojoSupport extends MojoSupport {
     public void executeMojo() throws MojoExecutionException, MojoFailureException {
         try {
             Optional<Session> njordSession = NjordUtils.mayGetNjordSession(mavenSession.getRepositorySession());
-            if (njordSession.isEmpty()) {
+            if (!njordSession.isPresent()) {
                 doWithoutSession();
             } else {
-                Session ns = njordSession.orElseThrow();
+                Session ns = njordSession.orElseThrow(J8Utils.OET);
                 if (ns.config().enabled()) {
                     doWithSession(ns);
                 } else {
@@ -79,12 +80,12 @@ public abstract class NjordMojoSupport extends MojoSupport {
         logger.info(
                 "    Checksum Factories: {}",
                 template.checksumAlgorithmFactories().isPresent()
-                        ? template.checksumAlgorithmFactories().orElseThrow()
+                        ? template.checksumAlgorithmFactories().orElseThrow(J8Utils.OET)
                         : "Globally configured");
         logger.info(
                 "    Omit checksums for: {}",
                 template.omitChecksumsForExtensions().isPresent()
-                        ? template.omitChecksumsForExtensions().orElseThrow()
+                        ? template.omitChecksumsForExtensions().orElseThrow(J8Utils.OET)
                         : "Globally configured");
     }
 
@@ -96,31 +97,31 @@ public abstract class NjordMojoSupport extends MojoSupport {
             logger.info("  Checksums:");
             logger.info(
                     "    Mandatory: {}",
-                    artifactStoreRequirements.mandatoryChecksumAlgorithms().isEmpty()
+                    !artifactStoreRequirements.mandatoryChecksumAlgorithms().isPresent()
                             ? "No checksum requirements set"
-                            : artifactStoreRequirements.mandatoryChecksumAlgorithms().orElseThrow().stream()
+                            : artifactStoreRequirements.mandatoryChecksumAlgorithms().orElseThrow(J8Utils.OET).stream()
                                     .map(ChecksumAlgorithmFactory::getName)
                                     .collect(Collectors.joining(", ")));
             logger.info(
                     "    Supported: {}",
-                    artifactStoreRequirements.optionalChecksumAlgorithms().isEmpty()
+                    !artifactStoreRequirements.optionalChecksumAlgorithms().isPresent()
                             ? "No checksum requirements set"
-                            : artifactStoreRequirements.optionalChecksumAlgorithms().orElseThrow().stream()
+                            : artifactStoreRequirements.optionalChecksumAlgorithms().orElseThrow(J8Utils.OET).stream()
                                     .map(ChecksumAlgorithmFactory::getName)
                                     .collect(Collectors.joining(", ")));
             logger.info("  Signatures:");
             logger.info(
                     "    Mandatory: {}",
-                    artifactStoreRequirements.mandatorySignatureTypes().isEmpty()
+                    !artifactStoreRequirements.mandatorySignatureTypes().isPresent()
                             ? "No signature requirements set"
-                            : artifactStoreRequirements.mandatorySignatureTypes().orElseThrow().stream()
+                            : artifactStoreRequirements.mandatorySignatureTypes().orElseThrow(J8Utils.OET).stream()
                                     .map(SignatureType::name)
                                     .collect(Collectors.joining(", ")));
             logger.info(
                     "    Supported: {}",
-                    artifactStoreRequirements.optionalSignatureTypes().isEmpty()
+                    !artifactStoreRequirements.optionalSignatureTypes().isPresent()
                             ? "No signature requirements set"
-                            : artifactStoreRequirements.optionalSignatureTypes().orElseThrow().stream()
+                            : artifactStoreRequirements.optionalSignatureTypes().orElseThrow(J8Utils.OET).stream()
                                     .map(SignatureType::name)
                                     .collect(Collectors.joining(", ")));
             logger.info("  Published artifacts will be available from:");

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
@@ -9,9 +9,11 @@ package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoFailureException;
@@ -53,13 +55,13 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
      */
     protected List<String> getArtifactStoreNameCandidates(Session ns) throws IOException {
         if (store == null && ns.config().prefix().isPresent()) {
-            String prefix = ns.config().prefix().orElseThrow();
+            String prefix = ns.config().prefix().orElseThrow(J8Utils.OET);
             return ns.artifactStoreManager().listArtifactStoreNamesForPrefix(prefix);
         }
         if (store != null) {
-            return List.of(store);
+            return Collections.singletonList(store);
         } else {
-            return List.of();
+            return Collections.emptyList();
         }
     }
 
@@ -84,16 +86,16 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
 
     protected ArtifactStore getArtifactStore(Session ns) throws IOException, MojoFailureException {
         Optional<String> storeName = getArtifactStoreName(ns);
-        if (storeName.isEmpty()) {
+        if (!storeName.isPresent()) {
             throw new MojoFailureException("ArtifactStore name was not specified nor could be found");
         }
-        String store = storeName.orElseThrow();
+        String store = storeName.orElseThrow(J8Utils.OET);
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
-        if (storeOptional.isEmpty()) {
+        if (!storeOptional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", store);
             throw new MojoFailureException("ArtifactStore with given name not found: " + store);
         }
-        return storeOptional.orElseThrow();
+        return storeOptional.orElseThrow(J8Utils.OET);
     }
 
     /**
@@ -114,14 +116,14 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
 
     protected ArtifactStorePublisher getArtifactStorePublisher(Session ns) throws MojoFailureException {
         Optional<String> publisherName = getArtifactStorePublisherName(ns);
-        if (publisherName.isEmpty()) {
+        if (!publisherName.isPresent()) {
             throw new MojoFailureException("Publisher name was not specified nor could be discovered");
         }
-        String publisher = publisherName.orElseThrow();
+        String publisher = publisherName.orElseThrow(J8Utils.OET);
         Optional<ArtifactStorePublisher> po = ns.selectArtifactStorePublisher(publisher);
-        if (po.isEmpty()) {
+        if (!po.isPresent()) {
             throw new MojoFailureException("Publisher not found: " + publisher);
         }
-        return po.orElseThrow();
+        return po.orElseThrow(J8Utils.OET);
     }
 }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/RedeployMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/RedeployMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.util.Optional;
@@ -41,15 +42,15 @@ public class RedeployMojo extends NjordMojoSupport {
     protected void doWithSession(Session ns) throws IOException {
         Optional<ArtifactStore> fromOptional = ns.artifactStoreManager().selectArtifactStore(from);
         Optional<ArtifactStore> toOptional = ns.artifactStoreManager().selectArtifactStore(to);
-        if (fromOptional.isEmpty()) {
+        if (!fromOptional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", from);
             return;
         }
-        if (toOptional.isEmpty()) {
+        if (!toOptional.isPresent()) {
             logger.warn("ArtifactStore with given name not found: {}", to);
             return;
         }
-        ns.artifactStoreMerger().redeploy(fromOptional.orElseThrow(), toOptional.orElseThrow());
+        ns.artifactStoreMerger().redeploy(fromOptional.orElseThrow(J8Utils.OET), toOptional.orElseThrow(J8Utils.OET));
         if (drop) {
             logger.info("Dropping {}", from);
             ns.artifactStoreManager().dropArtifactStore(from);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
@@ -53,7 +54,7 @@ public class StatusMojo extends PublisherSupportMojo {
 
         logger.info("Project deployment:");
         if (ns.config().prefix().isPresent()) {
-            logger.info("  Store prefix: {}", ns.config().prefix().orElseThrow());
+            logger.info("  Store prefix: {}", ns.config().prefix().orElseThrow(J8Utils.OET));
         }
         logger.info("* Release");
         logger.info("  Repository Id: {}", deploymentRelease.getId());
@@ -108,7 +109,7 @@ public class StatusMojo extends PublisherSupportMojo {
             for (String storeName : storeNameCandidates) {
                 Optional<ArtifactStore> aso = ns.artifactStoreManager().selectArtifactStore(storeName);
                 if (aso.isPresent()) {
-                    try (ArtifactStore artifactStore = aso.orElseThrow()) {
+                    try (ArtifactStore artifactStore = aso.orElseThrow(J8Utils.OET)) {
                         logger.info("  {}", artifactStore);
                     }
                 }
@@ -118,14 +119,14 @@ public class StatusMojo extends PublisherSupportMojo {
         logger.info("");
 
         Optional<String> pno = getArtifactStorePublisherName(ns);
-        if (pno.isEmpty()) {
+        if (!pno.isPresent()) {
             logger.info("No configured publishers found");
         } else {
             logger.info("Project publishing:");
-            String publisherName = pno.orElseThrow();
+            String publisherName = pno.orElseThrow(J8Utils.OET);
             Optional<ArtifactStorePublisher> po = ns.selectArtifactStorePublisher(publisherName);
             if (po.isPresent()) {
-                printPublisher(po.orElseThrow());
+                printPublisher(po.orElseThrow(J8Utils.OET));
             } else {
                 logger.warn("Unknown publisher set: {}", publisherName);
             }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ValidateMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/ValidateMojo.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreValidator;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
@@ -41,7 +42,7 @@ public class ValidateMojo extends PublisherSupportMojo {
             Optional<ArtifactStoreValidator.ValidationResult> vro = p.validate(from);
             if (vro.isPresent()) {
                 logger.info("Validated {} against {}", from, p.name());
-                ArtifactStoreValidator.ValidationResult vr = vro.orElseThrow();
+                ArtifactStoreValidator.ValidationResult vr = vro.orElseThrow(J8Utils.OET);
                 if (details) {
                     logger.info("Validation results for {}", from.name());
                     dumpValidationResult("", vr, full);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteBundleMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteBundleMojo.java
@@ -9,10 +9,12 @@ package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -41,12 +43,13 @@ public class WriteBundleMojo extends NjordMojoSupport {
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
         if (storeOptional.isPresent()) {
             Path targetDirectory =
-                    SessionConfig.getCanonicalPath(Path.of(directory).toAbsolutePath());
+                    SessionConfig.getCanonicalPath(Paths.get(directory).toAbsolutePath());
             if (!Files.isDirectory(targetDirectory)) {
                 Files.createDirectories(targetDirectory);
             }
             logger.info("Writing store {} as bundle to {}", store, directory);
-            Path result = ns.artifactStoreWriter().writeAsBundle(storeOptional.orElseThrow(), targetDirectory);
+            Path result =
+                    ns.artifactStoreWriter().writeAsBundle(storeOptional.orElseThrow(J8Utils.OET), targetDirectory);
             logger.info("Written to " + result);
         } else {
             logger.warn("ArtifactStore with given name not found");

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteMojo.java
@@ -9,10 +9,12 @@ package eu.maveniverse.maven.njord.plugin3;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -40,12 +42,13 @@ public class WriteMojo extends NjordMojoSupport {
         Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
         if (storeOptional.isPresent()) {
             Path targetDirectory =
-                    SessionConfig.getCanonicalPath(Path.of(directory).toAbsolutePath());
+                    SessionConfig.getCanonicalPath(Paths.get(directory).toAbsolutePath());
             if (Files.exists(targetDirectory)) {
                 throw new MojoExecutionException("Exporting to existing directory not supported");
             }
             logger.info("Writing store {} as directory to {}", store, directory);
-            Path result = ns.artifactStoreWriter().writeAsDirectory(storeOptional.orElseThrow(), targetDirectory);
+            Path result =
+                    ns.artifactStoreWriter().writeAsDirectory(storeOptional.orElseThrow(J8Utils.OET), targetDirectory);
             logger.info("Written to " + result);
         } else {
             logger.warn("ArtifactStore with given name not found");

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <version.maveniverseShared>0.1.5</version.maveniverseShared>
     <version.maven>3.9.9</version.maven>
     <version.resolver>1.9.22</version.resolver>
-    <version.slf4j>2.0.17</version.slf4j>
+    <version.slf4j>1.7.36</version.slf4j>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
 
     <!--
     Build time: latest stable Maven and Java 21+
-    Run time: current Maven (3.9+) and Java 11+
+    Run time: current Maven (3.9+) and Java 8+
     -->
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>8</maven.compiler.release>
     <requireRuntimeMavenVersion.range>[3.9,)</requireRuntimeMavenVersion.range>
 
     <!-- Dependency versions -->
@@ -177,12 +177,6 @@
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
         <version>${version.maven-plugin-tools}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.github.mizosoft.methanol</groupId>
-        <artifactId>methanol</artifactId>
-        <version>1.8.2</version>
       </dependency>
 
       <dependency>

--- a/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
+++ b/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherFactory;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
@@ -81,7 +82,7 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
                             "false")); // user specified explicitly what he wants here, but may override it
         } else if (session.config().currentProject().isPresent()) {
             SessionConfig.CurrentProject project =
-                    session.config().currentProject().orElseThrow();
+                    session.config().currentProject().orElseThrow(J8Utils.OET);
             releasesRepository = project.distributionManagementRepositories().get(RepositoryMode.RELEASE);
             snapshotsRepository = project.distributionManagementRepositories().get(RepositoryMode.SNAPSHOT);
         }

--- a/publisher/sonatype/pom.xml
+++ b/publisher/sonatype/pom.xml
@@ -53,11 +53,26 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.14</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <version>4.5.14</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.18.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
     <dependency>
@@ -83,6 +98,8 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.httpcomponents:*</include>
+                  <inclide>commons-codec:commons-codec</inclide>
+                  <include>org.slf4j:jcl-over-slf4j</include>
                 </includes>
               </artifactSet>
               <filters>

--- a/publisher/sonatype/pom.xml
+++ b/publisher/sonatype/pom.xml
@@ -118,6 +118,10 @@
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>eu.maveniverse.maven.njord.publisher.sonatype.shaded</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>eu.maveniverse.maven.njord.publisher.sonatype.shaded</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/publisher/sonatype/pom.xml
+++ b/publisher/sonatype/pom.xml
@@ -43,9 +43,21 @@
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-util</artifactId>
     </dependency>
+
     <dependency>
-      <groupId>com.github.mizosoft.methanol</groupId>
-      <artifactId>methanol</artifactId>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.16</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.5.14</version>
     </dependency>
 
     <dependency>
@@ -53,4 +65,47 @@
       <artifactId>javax.inject</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <dependencyReducedPomLocation>${build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.httpcomponents:*</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/DEPENDENCIES</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/NOTICE</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>eu.maveniverse.maven.njord.publisher.sonatype.shaded</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
@@ -89,7 +90,6 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 // build auth token
                 RemoteRepository authSource =
                         session.artifactPublisherRedirector().getAuthRepositoryId(repository, true);
-                String authKey = "Authorization";
                 String authValue = null;
                 try (AuthenticationContext repoAuthContext = AuthenticationContext.forRepository(
                         session.config().session(),
@@ -124,7 +124,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                     builder.addBinaryBody("bundle", bundle.toFile(), ContentType.DEFAULT_BINARY, bundleName);
 
                     HttpPost post = new HttpPost(repository.getUrl());
-                    post.setHeader(authKey, authValue);
+                    post.setHeader(HttpHeaders.AUTHORIZATION, authValue);
                     post.setEntity(builder.build());
                     try (CloseableHttpResponse response = httpClient.execute(post)) {
                         if (response.getStatusLine().getStatusCode() == 201) {

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -119,11 +119,13 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                 try (CloseableHttpClient httpClient =
                         HttpClientBuilder.create().setUserAgent(userAgent).build()) {
-                    HttpPost post = new HttpPost(repository.getUrl());
-                    post.setHeader(authKey, authValue);
                     MultipartEntityBuilder builder = MultipartEntityBuilder.create();
                     builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
                     builder.addBinaryBody("bundle", bundle.toFile(), ContentType.DEFAULT_BINARY, bundleName);
+
+                    HttpPost post = new HttpPost(repository.getUrl());
+                    post.setHeader(authKey, authValue);
+                    post.setEntity(builder.build());
                     try (CloseableHttpResponse response = httpClient.execute(post)) {
                         if (response.getStatusLine().getStatusCode() == 201) {
                             deploymentId = EntityUtils.toString(response.getEntity());

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -9,13 +9,9 @@ package eu.maveniverse.maven.njord.publisher.sonatype;
 
 import static java.util.Objects.requireNonNull;
 
-import com.github.mizosoft.methanol.MediaType;
-import com.github.mizosoft.methanol.Methanol;
-import com.github.mizosoft.methanol.MoreBodyPublishers;
-import com.github.mizosoft.methanol.MultipartBodyPublisher;
-import com.github.mizosoft.methanol.MutableRequest;
 import eu.maveniverse.maven.njord.shared.NjordUtils;
 import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.impl.store.ArtifactStoreDeployer;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherSupport;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
@@ -23,12 +19,18 @@ import eu.maveniverse.maven.njord.shared.publisher.MavenCentralPublisherFactory;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import eu.maveniverse.maven.shared.core.fs.FileUtils;
 import java.io.IOException;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
@@ -77,10 +79,10 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                 }
                 String bundleName = bundle.getFileName().toString();
                 if (publisherConfig.bundleName().isPresent()) {
-                    bundleName = publisherConfig.bundleName().orElseThrow();
+                    bundleName = publisherConfig.bundleName().orElseThrow(J8Utils.OET);
                 } else if (artifactStore.originProjectArtifact().isPresent()) {
                     Artifact originProjectArtifact =
-                            artifactStore.originProjectArtifact().orElseThrow();
+                            artifactStore.originProjectArtifact().orElseThrow(J8Utils.OET);
                     bundleName = originProjectArtifact.getArtifactId() + "-" + originProjectArtifact.getVersion();
                 }
 
@@ -108,37 +110,28 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                 // we need to use own HTTP client here
                 String deploymentId;
-                try {
-                    // use Maven UA
-                    String userAgent = ConfigUtils.getString(
-                            session.config().session(),
-                            ConfigurationProperties.DEFAULT_USER_AGENT,
-                            "aether.connector.userAgent",
-                            "aether.transport.http.userAgent");
+                // use Maven UA
+                String userAgent = ConfigUtils.getString(
+                        session.config().session(),
+                        ConfigurationProperties.DEFAULT_USER_AGENT,
+                        "aether.connector.userAgent",
+                        "aether.transport.http.userAgent");
 
-                    Methanol httpClient =
-                            Methanol.newBuilder().userAgent(userAgent).build();
-                    MultipartBodyPublisher multipartBodyPublisher = MultipartBodyPublisher.newBuilder()
-                            .formPart(
-                                    "bundle",
-                                    bundleName,
-                                    MoreBodyPublishers.ofMediaType(
-                                            HttpRequest.BodyPublishers.ofFile(bundle),
-                                            MediaType.APPLICATION_OCTET_STREAM))
-                            .build();
-                    HttpResponse<String> response = httpClient.send(
-                            MutableRequest.POST(repository.getUrl(), multipartBodyPublisher)
-                                    .header(authKey, authValue),
-                            HttpResponse.BodyHandlers.ofString());
-                    if (response.statusCode() == 201) {
-                        deploymentId = response.body();
-                    } else {
-                        throw new IOException(
-                                "Unexpected response code: " + response.statusCode() + " " + response.body());
+                try (CloseableHttpClient httpClient =
+                        HttpClientBuilder.create().setUserAgent(userAgent).build()) {
+                    HttpPost post = new HttpPost(repository.getUrl());
+                    post.setHeader(authKey, authValue);
+                    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+                    builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+                    builder.addBinaryBody("bundle", bundle.toFile(), ContentType.DEFAULT_BINARY, bundleName);
+                    try (CloseableHttpResponse response = httpClient.execute(post)) {
+                        if (response.getStatusLine().getStatusCode() == 201) {
+                            deploymentId = EntityUtils.toString(response.getEntity());
+                        } else {
+                            throw new IOException("Unexpected response code: " + response.getStatusLine() + " "
+                                    + (response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : ""));
+                        }
                     }
-                } catch (InterruptedException e) {
-                    logger.error(e.getMessage(), e);
-                    throw new IOException("Publishing interrupted", e);
                 }
 
                 logger.info("Deployment ID: {}", deploymentId);

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralRequirements.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralRequirements.java
@@ -29,6 +29,8 @@ import eu.maveniverse.maven.njord.shared.publisher.spi.ValidatorFactory;
 import eu.maveniverse.maven.njord.shared.publisher.spi.signature.SignatureType;
 import eu.maveniverse.maven.njord.shared.publisher.spi.signature.SignatureValidator;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
@@ -51,14 +53,16 @@ public class SonatypeCentralRequirements implements ArtifactStoreRequirements {
         requireNonNull(modelProvider);
 
         // checksums
-        this.mandatoryChecksumAlgorithms = checksumAlgorithmFactorySelector.selectList(List.of("SHA-1", "MD5"));
-        this.optionalChecksumAlgorithms = checksumAlgorithmFactorySelector.selectList(List.of("SHA-512", "SHA-256"));
+        this.mandatoryChecksumAlgorithms = checksumAlgorithmFactorySelector.selectList(Arrays.asList("SHA-1", "MD5"));
+        this.optionalChecksumAlgorithms =
+                checksumAlgorithmFactorySelector.selectList(Arrays.asList("SHA-512", "SHA-256"));
 
         // signatures
-        this.mandatorySignatureTypes = List.of(new GpgSignatureType());
-        this.optionalSignatureTypes = List.of(new SigstoreSignatureType());
-        List<SignatureValidator> mandatorySignatureValidators = List.of(new GpgSignatureValidator());
-        List<SignatureValidator> optionalSignatureValidators = List.of(new SigstoreSignatureValidator());
+        this.mandatorySignatureTypes = Collections.singletonList(new GpgSignatureType());
+        this.optionalSignatureTypes = Collections.singletonList(new SigstoreSignatureType());
+        List<SignatureValidator> mandatorySignatureValidators = Collections.singletonList(new GpgSignatureValidator());
+        List<SignatureValidator> optionalSignatureValidators =
+                Collections.singletonList(new SigstoreSignatureValidator());
 
         // rest
         ArrayList<ValidatorFactory> validators = new ArrayList<>();
@@ -84,8 +88,8 @@ public class SonatypeCentralRequirements implements ArtifactStoreRequirements {
                 optionalSignatureTypes,
                 optionalSignatureValidators));
 
-        this.releaseValidator =
-                new DefaultArtifactStoreValidator(session, "central", "Central Requirements", List.of(), validators);
+        this.releaseValidator = new DefaultArtifactStoreValidator(
+                session, "central", "Central Requirements", Collections.emptyList(), validators);
         this.snapshotValidator = null;
     }
 


### PR DESCRIPTION
We can downgrade to Java 8+ quite easily (just give up on j.n.h.HttpClient and some sugar). OTOH, we cannot give up Maven 3.9+ runtime requirement (we need Resolver Checksum API from 1.9 that is present in Maven 3.9).

The reason why I opted to shade/relocate whole ASF httpClient suite (httpcore, httpclient, httpmime) to be for sure independent from Maven Core that contains core and client, but not mime. On the other hand, these three must be aligned.