### PR TITLE
Small fix for Maven 3.8 and older

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -76,7 +76,8 @@
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-util</artifactId>
-      <scope>provided</scope>
+      <!-- To not crap out on older Maven -->
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>


### PR DESCRIPTION
If extension is set in POM, to not explode but show somewhat civilized error instead.