### PR TITLE
WaitOnStates: a very simple solution to make CP publisher wait

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisher.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisher.java
@@ -57,4 +57,17 @@ public interface ArtifactStorePublisher {
      * Performs the publishing.
      */
     void publish(ArtifactStore artifactStore) throws IOException;
+
+    /**
+     * Special exception that signals that publishing failed as signaled by service.
+     */
+    class PublishFailedException extends IOException {
+        public PublishFailedException(String message) {
+            super(message);
+        }
+
+        public PublishFailedException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
 }

--- a/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
@@ -91,6 +91,7 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
                             }
                         } else {
                             try {
+                                logger.info("Auto publish: Publishing stores created in this session");
                                 int published = njordSession.publishSessionArtifactStores();
                                 if (published != 0) {
                                     logger.info("Auto publish: Published {} stores created in this session", published);

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublishMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublishMojo.java
@@ -31,7 +31,11 @@ public class PublishMojo extends PublisherSupportMojo {
         try (ArtifactStore from = getArtifactStore(ns)) {
             ArtifactStorePublisher publisher = getArtifactStorePublisher(ns);
             logger.info("Publishing {} with {}", from, publisher.name());
-            publisher.publish(from);
+            try {
+                publisher.publish(from);
+            } catch (ArtifactStorePublisher.PublishFailedException e) {
+                throw new MojoFailureException(e.getMessage(), e);
+            }
         }
         if (drop) {
             logger.info("Dropping {}", store);

--- a/publisher/sonatype/pom.xml
+++ b/publisher/sonatype/pom.xml
@@ -75,6 +75,11 @@
       <version>1.18.0</version>
     </dependency>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20250517</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -130,8 +130,9 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                     if (publisherConfig.waitForStates()) {
                         logger.info(
-                                "Waiting for states past {}... (timeout {})",
+                                "Waiting for states past {}... (poll {}; timeout {})",
                                 publisherConfig.waitForStatesWaitStates(),
+                                publisherConfig.waitForStatesSleep(),
                                 publisherConfig.waitForStatesTimeout());
                         Instant waitingUntil = Instant.now().plus(publisherConfig.waitForStatesTimeout());
                         try {

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -23,7 +23,9 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Base64;
+import java.util.Locale;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -41,6 +43,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.ConfigUtils;
+import org.json.JSONObject;
 
 public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSupport {
     private final SonatypeCentralPortalPublisherConfig publisherConfig;
@@ -121,34 +124,45 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                 try (CloseableHttpClient httpClient =
                         HttpClientBuilder.create().setUserAgent(userAgent).build()) {
-                    MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-                    builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
-                    builder.addBinaryBody("bundle", bundle.toFile(), ContentType.DEFAULT_BINARY, bundleName);
-
                     URIBuilder uriBuilder = new URIBuilder(repository.getUrl());
-                    uriBuilder.addParameter("name", bundleName);
-                    if (publisherConfig.publishingType().isPresent()) {
-                        uriBuilder.addParameter(
-                                "publishingType",
-                                publisherConfig.publishingType().orElseThrow(J8Utils.OET));
-                    }
+                    deploymentId = upload(httpClient, uriBuilder, authValue, bundle, bundleName);
+                    logger.info("Deployment ID: {}", deploymentId);
 
-                    HttpPost post = new HttpPost(uriBuilder.build());
-                    post.setHeader(HttpHeaders.AUTHORIZATION, authValue);
-                    post.setEntity(builder.build());
-                    try (CloseableHttpResponse response = httpClient.execute(post)) {
-                        if (response.getStatusLine().getStatusCode() == 201) {
-                            deploymentId = EntityUtils.toString(response.getEntity());
-                        } else {
-                            throw new IOException("Unexpected response code: " + response.getStatusLine() + " "
-                                    + (response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : ""));
+                    if (publisherConfig.waitForStates()) {
+                        logger.info("Waiting for validation...");
+                        Instant waitingUntil = Instant.now().plus(publisherConfig.waitForStatesTimeout());
+                        try {
+                            String deploymentState = deploymentState(httpClient, uriBuilder, authValue, deploymentId);
+                            logger.debug("deploymentState = {}", deploymentState);
+                            while (publisherConfig.waitForStatesWaitStates().contains(deploymentState)) {
+                                if (Instant.now().isAfter(waitingUntil)) {
+                                    throw new IOException(
+                                            "Timeout on waiting for validation for deployment " + deploymentId);
+                                }
+                                Thread.sleep(
+                                        publisherConfig.waitForStatesSleep().toMillis());
+
+                                deploymentState = deploymentState(httpClient, uriBuilder, authValue, deploymentId);
+                                logger.debug("deploymentState = {}", deploymentState);
+                            }
+
+                            if (publisherConfig.waitForStatesSuccessStates().contains(deploymentState)) {
+                                logger.info("Publishing succeeded: {}", deploymentState);
+                            } else if (publisherConfig
+                                    .waitForStatesFailureStates()
+                                    .contains(deploymentState)) {
+                                logger.warn("Publishing failed: {}", deploymentState);
+                                throw new IOException("Publishing failed: " + deploymentState);
+                            } else {
+                                logger.warn("Unknown non-wait state: {}", deploymentState);
+                            }
+                        } catch (InterruptedException e) {
+                            throw new IOException(e.getMessage(), e);
                         }
                     }
                 } catch (URISyntaxException e) {
                     throw new IOException(e.getMessage(), e);
                 }
-
-                logger.info("Deployment ID: {}", deploymentId);
             } finally {
                 if (Files.isDirectory(tmpDir)) {
                     FileUtils.deleteRecursively(tmpDir);
@@ -166,6 +180,58 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                                 session.artifactPublisherRedirector().getPublishingRepository(repository, true, true),
                                 true)
                         .deploy(store);
+            }
+        }
+    }
+
+    private String upload(
+            CloseableHttpClient httpClient,
+            URIBuilder uriBuilder,
+            String authorizationHeader,
+            Path bundle,
+            String bundleName)
+            throws IOException, URISyntaxException {
+        uriBuilder.clearParameters();
+        uriBuilder.setPath("/api/v1/publisher/upload");
+        uriBuilder.addParameter("name", bundleName);
+        if (publisherConfig.publishingType().isPresent()) {
+            uriBuilder.addParameter(
+                    "publishingType", publisherConfig.publishingType().orElseThrow(J8Utils.OET));
+        }
+
+        HttpPost post = new HttpPost(uriBuilder.build());
+        post.setHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+        builder.addBinaryBody("bundle", bundle.toFile(), ContentType.DEFAULT_BINARY, bundleName);
+        post.setEntity(builder.build());
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            if (response.getStatusLine().getStatusCode() == 201) {
+                return EntityUtils.toString(response.getEntity());
+            } else {
+                throw new IOException("Unexpected response code: " + response.getStatusLine() + " "
+                        + (response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : ""));
+            }
+        }
+    }
+
+    private String deploymentState(
+            CloseableHttpClient httpClient, URIBuilder uriBuilder, String authorizationHeader, String deploymentId)
+            throws IOException, URISyntaxException {
+        uriBuilder.clearParameters();
+        uriBuilder.setPath("/api/v1/publisher/status");
+        uriBuilder.addParameter("id", deploymentId);
+        HttpPost post = new HttpPost(uriBuilder.build());
+        post.setHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+        post.setHeader(HttpHeaders.ACCEPT, "application/json");
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            if (response.getStatusLine().getStatusCode() == 200) {
+                return new JSONObject(EntityUtils.toString(response.getEntity()))
+                        .optString("deploymentState")
+                        .toLowerCase(Locale.ENGLISH);
+            } else {
+                throw new IOException("Unexpected response code: " + response.getStatusLine() + " "
+                        + (response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : ""));
             }
         }
     }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -129,7 +129,10 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                     logger.info("Deployment ID: {}", deploymentId);
 
                     if (publisherConfig.waitForStates()) {
-                        logger.info("Waiting for states...");
+                        logger.info(
+                                "Waiting for states past {}... (timeout {})",
+                                publisherConfig.waitForStatesWaitStates(),
+                                publisherConfig.waitForStatesTimeout());
                         Instant waitingUntil = Instant.now().plus(publisherConfig.waitForStatesTimeout());
                         try {
                             String deploymentState = deploymentState(httpClient, uriBuilder, authValue, deploymentId);
@@ -148,7 +151,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                             if (publisherConfig.waitForStatesFailureStates().contains(deploymentState)) {
                                 throw new PublishFailedException("Publishing of deployment " + deploymentId
-                                        + " failed; transitioned to failure state '" + deploymentState + "'");
+                                        + " failed; transitioned to failure state: " + deploymentState);
                             } else {
                                 logger.info("Publishing of deployment {} succeeded: {}", deploymentId, deploymentState);
                             }
@@ -192,7 +195,8 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
         uriBuilder.addParameter("name", bundleName);
         if (publisherConfig.publishingType().isPresent()) {
             uriBuilder.addParameter(
-                    "publishingType", publisherConfig.publishingType().orElseThrow(J8Utils.OET));
+                    "publishingType",
+                    publisherConfig.publishingType().orElseThrow(J8Utils.OET).toUpperCase(Locale.ENGLISH));
         }
 
         HttpPost post = new HttpPost(uriBuilder.build());

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -129,7 +129,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                     logger.info("Deployment ID: {}", deploymentId);
 
                     if (publisherConfig.waitForStates()) {
-                        logger.info("Waiting for validation...");
+                        logger.info("Waiting for states...");
                         Instant waitingUntil = Instant.now().plus(publisherConfig.waitForStatesTimeout());
                         try {
                             String deploymentState = deploymentState(httpClient, uriBuilder, authValue, deploymentId);
@@ -146,15 +146,11 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                                 logger.debug("deploymentState = {}", deploymentState);
                             }
 
-                            if (publisherConfig.waitForStatesSuccessStates().contains(deploymentState)) {
-                                logger.info("Publishing succeeded: {}", deploymentState);
-                            } else if (publisherConfig
-                                    .waitForStatesFailureStates()
-                                    .contains(deploymentState)) {
-                                logger.warn("Publishing failed: {}", deploymentState);
-                                throw new IOException("Publishing failed: " + deploymentState);
+                            if (publisherConfig.waitForStatesFailureStates().contains(deploymentState)) {
+                                throw new PublishFailedException("Publishing of deployment " + deploymentId
+                                        + " failed; transitioned to failure state '" + deploymentState + "'");
                             } else {
-                                logger.warn("Unknown non-wait state: {}", deploymentState);
+                                logger.info("Publishing of deployment {} succeeded: {}", deploymentId, deploymentState);
                             }
                         } catch (InterruptedException e) {
                             throw new IOException(e.getMessage(), e);

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -130,10 +130,11 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                     if (publisherConfig.waitForStates()) {
                         logger.info(
-                                "Waiting for states past {}... (poll {}; timeout {})",
+                                "Waiting for states past {}... (poll {}; timeout {}, failed states {})",
                                 publisherConfig.waitForStatesWaitStates(),
                                 publisherConfig.waitForStatesSleep(),
-                                publisherConfig.waitForStatesTimeout());
+                                publisherConfig.waitForStatesTimeout(),
+                                publisherConfig.waitForStatesFailureStates());
                         Instant waitingUntil = Instant.now().plus(publisherConfig.waitForStatesTimeout());
                         try {
                             String deploymentState = deploymentState(httpClient, uriBuilder, authValue, deploymentId);

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -110,26 +110,29 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
         // njord.publisher.sonatype-cp.waitForStatesWaitStates
         this.waitForStatesWaitStates = Collections.unmodifiableSet(
                 new HashSet<>(ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
-                        sessionConfig.effectiveProperties(),
-                        "pending,validating",
-                        keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesWaitStates"),
-                        SessionConfig.KEY_PREFIX + "waitForStatesWaitStates").toLowerCase(Locale.ENGLISH))));
+                                sessionConfig.effectiveProperties(),
+                                "pending,validating",
+                                keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesWaitStates"),
+                                SessionConfig.KEY_PREFIX + "waitForStatesWaitStates")
+                        .toLowerCase(Locale.ENGLISH))));
 
         // njord.publisher.sonatype-cp.waitForStatesSuccessStates
         this.waitForStatesSuccessStates = Collections.unmodifiableSet(
                 new HashSet<>(ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
-                        sessionConfig.effectiveProperties(),
-                        "validated,published",
-                        keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesSuccessStates"),
-                        SessionConfig.KEY_PREFIX + "waitForStatesSuccessStates").toLowerCase(Locale.ENGLISH))));
+                                sessionConfig.effectiveProperties(),
+                                "validated,published",
+                                keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesSuccessStates"),
+                                SessionConfig.KEY_PREFIX + "waitForStatesSuccessStates")
+                        .toLowerCase(Locale.ENGLISH))));
 
         // njord.publisher.sonatype-cp.waitForStatesFailureStates
         this.waitForStatesFailureStates = Collections.unmodifiableSet(
                 new HashSet<>(ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
-                        sessionConfig.effectiveProperties(),
-                        "failed",
-                        keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesFailureStates"),
-                        SessionConfig.KEY_PREFIX + "waitForStatesFailureStates").toLowerCase(Locale.ENGLISH))));
+                                sessionConfig.effectiveProperties(),
+                                "failed",
+                                keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesFailureStates"),
+                                SessionConfig.KEY_PREFIX + "waitForStatesFailureStates")
+                        .toLowerCase(Locale.ENGLISH))));
     }
 
     public Optional<String> bundleName() {

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -34,7 +34,6 @@ import org.eclipse.aether.util.ConfigUtils;
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesTimeout</code> (alias <code>njord.waitForStatesTimeout</code>) - how long should publisher wait for validation in total? (def: PT15M)</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesSleep</code> (alias <code>njord.waitForStatesSleep</code>) - how long should publisher sleep between each state check (def: PT1S)</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesWaitStates</code> (alias <code>njord.waitForStatesWaitStates</code>) - the comma separated states that publisher should wait CP to transition from (def: "pending,validating")</li>
- *     <li><code>njord.publisher.sonatype-cp.waitForStatesSuccessStates</code> (alias <code>njord.waitForStatesWaitStates</code>) - the comma separated states that publisher should consider as success (def: "validated,published")</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesFailureStates</code> (alias <code>njord.waitForStatesFailureStates</code>) - the comma separated states that publisher should consider as failure (def: "failed")</li>
  * </ul>
  * The property <code>njord.publisher.sonatype-cp.bundleName</code> defines the bundle name that is shown on CP WebUI.
@@ -54,7 +53,6 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
     private final Duration waitForStatesTimeout;
     private final Duration waitForStatesSleep;
     private final Set<String> waitForStatesWaitStates;
-    private final Set<String> waitForStatesSuccessStates;
     private final Set<String> waitForStatesFailureStates;
 
     public SonatypeCentralPortalPublisherConfig(SessionConfig sessionConfig) {
@@ -116,15 +114,6 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
                                 SessionConfig.KEY_PREFIX + "waitForStatesWaitStates")
                         .toLowerCase(Locale.ENGLISH))));
 
-        // njord.publisher.sonatype-cp.waitForStatesSuccessStates
-        this.waitForStatesSuccessStates = Collections.unmodifiableSet(
-                new HashSet<>(ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
-                                sessionConfig.effectiveProperties(),
-                                "validated,published",
-                                keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesSuccessStates"),
-                                SessionConfig.KEY_PREFIX + "waitForStatesSuccessStates")
-                        .toLowerCase(Locale.ENGLISH))));
-
         // njord.publisher.sonatype-cp.waitForStatesFailureStates
         this.waitForStatesFailureStates = Collections.unmodifiableSet(
                 new HashSet<>(ConfigUtils.parseCommaSeparatedUniqueNames(ConfigUtils.getString(
@@ -157,10 +146,6 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
 
     public Set<String> waitForStatesWaitStates() {
         return waitForStatesWaitStates;
-    }
-
-    public Set<String> waitForStatesSuccessStates() {
-        return waitForStatesSuccessStates;
     }
 
     public Set<String> waitForStatesFailureStates() {

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -32,7 +32,7 @@ import org.eclipse.aether.util.ConfigUtils;
  *     <li><code>njord.publisher.sonatype-cp.publishingType</code> (alias <code>njord.publishingType</code>) - the "publishing type": USER_MANAGED, AUTOMATIC</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStates</code> (alias <code>njord.waitForStates</code>) - should publisher wait for state transitions? (def: false)</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesTimeout</code> (alias <code>njord.waitForStatesTimeout</code>) - how long should publisher wait for validation in total? (def: PT15M)</li>
- *     <li><code>njord.publisher.sonatype-cp.waitForStatesSleep</code> (alias <code>njord.waitForStatesSleep</code>) - how long should publisher sleep between each state check (def: PT1S)</li>
+ *     <li><code>njord.publisher.sonatype-cp.waitForStatesSleep</code> (alias <code>njord.waitForStatesSleep</code>) - how long should publisher sleep between each state check (def: PT10S)</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesWaitStates</code> (alias <code>njord.waitForStatesWaitStates</code>) - the comma separated states that publisher should wait CP to transition from (def: "pending,validating")</li>
  *     <li><code>njord.publisher.sonatype-cp.waitForStatesFailureStates</code> (alias <code>njord.waitForStatesFailureStates</code>) - the comma separated states that publisher should consider as failure (def: "failed")</li>
  * </ul>
@@ -98,7 +98,7 @@ public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig 
         // njord.publisher.sonatype-cp.waitForStatesSleep
         this.waitForStatesSleep = Duration.parse(ConfigUtils.getString(
                 sessionConfig.effectiveProperties(),
-                "PT1S",
+                "PT10S",
                 keyName(SonatypeCentralPortalPublisherFactory.NAME, "waitForStatesSleep"),
                 SessionConfig.KEY_PREFIX + "waitForStatesSleep"));
         if (this.waitForStatesSleep.isNegative()) {

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisherConfig.java
@@ -39,7 +39,7 @@ import org.eclipse.aether.util.ConfigUtils;
  * The property <code>njord.publisher.sonatype-cp.bundleName</code> defines the bundle name that is shown on CP WebUI.
  * By default, value of <code>${project.artifactId}-${project.version}</code> is used IF current project is present.
  * Also <a href="https://central.sonatype.com/api-doc">see API documentation.</a>
- * Note: "states" should be lowercase strings.
+ * Note: publishingType, waitForStatesWaitStates and waitForStatesFailureStates are case-insensitive (are converted to required case).
  */
 public final class SonatypeCentralPortalPublisherConfig extends PublisherConfig {
     public static final String RELEASE_REPOSITORY_ID = "sonatype-cp";


### PR DESCRIPTION
This makes Njord able to wait for given state transitions, and fail the build if transition should be considered failure. This is intentionally done "low key" and simplest as possible, but at the same made somewhat flexible as well.

Example flow in "happy path" and "bad path":
https://gist.github.com/cstamas/fdd74a9a140ea672cb95d3d19b1c1891

Fixes #113
Fixes #115 