### PR TITLE
Clean up settings management; Maven 3.9.10

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -27,14 +27,10 @@ import java.util.Properties;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.model.DeploymentRepository;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
-import org.eclipse.aether.util.ConfigUtils;
 
 /**
  * Session config holds all the session related data.
@@ -182,14 +178,6 @@ public interface SessionConfig {
     Optional<String> prefix();
 
     /**
-     * The publisher to use, if specified.
-     * <p>
-     * User may specify it in user properties, like in {@code .mvn/maven.config} or CLI, but also in top level
-     * POM as project property.
-     */
-    Optional<String> publisher();
-
-    /**
      * Shim for "current project". Provides needed information from project.
      */
     interface CurrentProject {
@@ -226,37 +214,6 @@ public interface SessionConfig {
      * this field with be empty.
      */
     Optional<CurrentProject> currentProject();
-
-    /**
-     * Returns the "service configuration" for given service ID.
-     */
-    default Optional<Map<String, String>> serviceConfiguration(String serviceId) {
-        requireNonNull(serviceId);
-        Object configuration = ConfigUtils.getObject(
-                session(),
-                null,
-                "aether.connector.wagon.config." + serviceId,
-                "aether.transport.wagon.config." + serviceId);
-        if (configuration != null) {
-            PlexusConfiguration config;
-            if (configuration instanceof PlexusConfiguration) {
-                config = (PlexusConfiguration) configuration;
-            } else if (configuration instanceof Xpp3Dom) {
-                config = new XmlPlexusConfiguration((Xpp3Dom) configuration);
-            } else {
-                throw new IllegalArgumentException("unexpected configuration type: "
-                        + configuration.getClass().getName());
-            }
-            HashMap<String, String> serviceConfiguration = new HashMap<>();
-            for (PlexusConfiguration child : config.getChildren()) {
-                if (child.getName().startsWith(KEY_PREFIX) && child.getValue() != null) {
-                    serviceConfiguration.put(child.getName(), child.getValue());
-                }
-            }
-            return Optional.of(serviceConfiguration);
-        }
-        return Optional.empty();
-    }
 
     /**
      * Returns this instance as builder.
@@ -459,7 +416,6 @@ public interface SessionConfig {
             private final boolean autoPublish;
             private final boolean autoDrop;
             private final String prefix;
-            private final String publisher;
             private final CurrentProject currentProject;
 
             private Impl(
@@ -536,7 +492,6 @@ public interface SessionConfig {
                     prefixString = currentProject.artifact().getArtifactId();
                 }
                 this.prefix = prefixString;
-                this.publisher = effectiveProperties.get(CONFIG_PUBLISHER);
             }
 
             @Override
@@ -611,11 +566,6 @@ public interface SessionConfig {
             @Override
             public Optional<String> prefix() {
                 return Optional.ofNullable(prefix);
-            }
-
-            @Override
-            public Optional<String> publisher() {
-                return Optional.ofNullable(publisher);
             }
 
             @Override

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -92,8 +92,9 @@ public interface SessionConfig {
     String CONFIG_AUTH_REDIRECT = KEY_PREFIX + "authRedirect";
 
     /**
-     * Configuration key in {@code settings/servers/server/configuration} for server redirect. If this
-     * key is present, Njord will take service config from redirected server entry instead.
+     * Configuration key in {@code settings/servers/server/configuration} for service redirect. If this
+     * key is present, all other keys are ignored and Njord will take service config from redirected server entry
+     * instead.
      */
     String CONFIG_SERVICE_REDIRECT = KEY_PREFIX + "serviceRedirect";
 

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -92,6 +92,12 @@ public interface SessionConfig {
     String CONFIG_AUTH_REDIRECT = KEY_PREFIX + "authRedirect";
 
     /**
+     * Configuration key in {@code settings/servers/server/configuration} for server redirect. If this
+     * key is present, Njord will take service config from redirected server entry instead.
+     */
+    String CONFIG_SERVICE_REDIRECT = KEY_PREFIX + "serverRedirect";
+
+    /**
      * Is Njord enabled? If this method returns {@code false}, Njord will step aside (like it was not loaded).
      */
     boolean enabled();

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/SessionConfig.java
@@ -95,7 +95,7 @@ public interface SessionConfig {
      * Configuration key in {@code settings/servers/server/configuration} for server redirect. If this
      * key is present, Njord will take service config from redirected server entry instead.
      */
-    String CONFIG_SERVICE_REDIRECT = KEY_PREFIX + "serverRedirect";
+    String CONFIG_SERVICE_REDIRECT = KEY_PREFIX + "serviceRedirect";
 
     /**
      * Is Njord enabled? If this method returns {@code false}, Njord will step aside (like it was not loaded).

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirector.java
@@ -162,7 +162,7 @@ public class DefaultArtifactPublisherRedirector extends ComponentSupport impleme
     }
 
     /**
-     * Returns the "service configuration" for given service ID.
+     * Returns the "service configuration" for given server ID.
      */
     private Optional<Map<String, String>> serviceConfiguration(String serverId) {
         requireNonNull(serverId);

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirector.java
@@ -164,13 +164,13 @@ public class DefaultArtifactPublisherRedirector extends ComponentSupport impleme
     /**
      * Returns the "service configuration" for given service ID.
      */
-    private Optional<Map<String, String>> serviceConfiguration(String serviceId) {
-        requireNonNull(serviceId);
+    private Optional<Map<String, String>> serviceConfiguration(String serverId) {
+        requireNonNull(serverId);
         Object configuration = ConfigUtils.getObject(
                 session.config().session(),
                 null,
-                "aether.connector.wagon.config." + serviceId,
-                "aether.transport.wagon.config." + serviceId);
+                "aether.connector.wagon.config." + serverId,
+                "aether.transport.wagon.config." + serverId);
         if (configuration != null) {
             PlexusConfiguration config;
             if (configuration instanceof PlexusConfiguration) {

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
@@ -11,6 +11,89 @@ import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
 import java.util.Optional;
 import org.eclipse.aether.repository.RemoteRepository;
 
+/**
+ * Component responsible for config, remote repo URL and remote repo Auth extraction, while it follows various kinds
+ * of "redirections".
+ * <p>
+ * User can set up proper environment by editing own, user wide <code>settings.xml</code>. Ideally (and minimally), user
+ * should have as many auth-equipped server entries as much real publishing services user uses (for Central that is
+ * today 3 + 1: Sonatype OSS, Sonatype S01, Sonatype Central Portal and ASF). Out of these four 2 are being phased
+ * out (OSS and S01). Aside of auth, these entries should also contain Njord configuration such as
+ * {@link eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_PUBLISHER},
+ * {@link eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_RELEASE_URL} and optionally
+ * {@link eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_SNAPSHOT_URL} if snapshot staging is desired. Once
+ * user has these entries in own <code>settings.xml</code>, publishing is set up.
+ * <p>
+ * Historically, each OSS project "invented" their own Server ID in the <code>project/distributionManagement</code>,
+ * so today we have many server IDs in use <em>despite almost all of use one of these 4 services to publish</em>.
+ * This lead to issues, when one user maintains several "namespaces" (several unrelated groupID publishing to Central),
+ * as this user needs to copy-paste all these server entries with <em>same auth</em> to be able to publish. Moreover,
+ * is just chaotic, as people "invented" various names for these services.
+ * <p>
+ * Take for example Sonatype Central Portal setup:
+ * The recommended entry in user <code>settings.xml</code> is following (replace {@code $TOKEN1} and {@code $TOKEN2} with Central Portal generated tokens):
+ * <pre>{@code
+ *     <server>
+ *       <id>sonatype-central-portal</id>
+ *       <username>$TOKEN1</username>
+ *       <password>$TOKEN2</password>
+ *       <configuration>
+ *         <njord.publisher>sonatype-cp</njord.publisher>
+ *         <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+ *       </configuration>
+ *     </server>
+ * }</pre>
+ * <p>
+ * The recommended POM distribution management entry for Central Portal w/ snapshot publishing enabled is this:
+ * <pre>{@code
+ *   <distributionManagement>
+ *     <repository>
+ *       <id>sonatype-central-portal</id>
+ *       <name>Sonatype Central Portal</name>
+ *       <url>https://repo.maven.apache.org/maven2/</url>
+ *     </repository>
+ *     <snapshotRepository>
+ *       <id>sonatype-central-portal</id>
+ *       <name>Sonatype Central Portal</name>
+ *       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+ *     </snapshotRepository>
+ *   </distributionManagement>
+ * }</pre>
+ * This entry tells the "truth", in a way it tells exactly where it publishes, and from where the artifacts are available
+ * once they are published. This latter is important, as before it was common to have some "service URL" here, that had nothing to
+ * do with "published artifacts whereabouts", it was always implied. But, some tools like SBOM managers do like to have
+ * this information, instead to guess them. Similarly for snapshot publishing, it is <em>same service</em>, hence
+ * same auth is needed for it as well.
+ * <p>
+ * Moreover, consider if some vendor changes service endpoint (like goes V2 from V1). Having service endpoint in here
+ * is not future-proof. Also, it does not express where the published artifacts go. Finally, all you do is "just publish
+ * to Central", so why should POM differ from project that use service A from service B, while they both publish to
+ * Central? Does it matter HOW you publish, while the WHERE you publish remain same?  Is silly.
+ * <p>
+ * Njord encourages this setup:
+ * <ul>
+ *     <li>have only as many properly identified auth-equipped entries in your <code>settings.xml</code> as many you really use (stop copy-paste, no duplicates)</li>
+ *     <li>ideally, your POM should tell the "truth", and not use some invented server ID and service/proprietary URL</li>
+ *     <li>if not possible, it allows you to create "redirects" in your <code>settings.xml</code> to overcome this chaos</li>
+ * </ul>
+ * <p>
+ * In case you need to publish a project that does not follow these rules, and assume it uses some invented server IDs,
+ * like "the-project-releases", but in reality it wants to use Central Portal, just add this entry to your user
+ * <code>settings.xml</code>:
+ * <pre>{@code
+ *     <server>
+ *       <id>the-project-releases</id>
+ *       <configuration>
+ *         <njord.redirectService>sonatype-central-portal</njord.redirectService>
+ *       </configuration>
+ *     </server>
+ * }</pre>
+ * And that is it: no copy pasta needed: if you cannot change the project distribution management, just reidrect it
+ * to proper service.
+ *
+ * @see eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_SERVICE_REDIRECT
+ * @see eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_AUTH_REDIRECT
+ */
 public interface ArtifactPublisherRedirector {
     /**
      * Tells, based on Njord config, what is the real URL used for given remote repository. Never returns {@code null},

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
@@ -89,7 +89,7 @@ import org.eclipse.aether.repository.RemoteRepository;
  *       </configuration>
  *     </server>
  * }</pre>
- * And that is it: no copy pasta needed: if you cannot change the project distribution management, just redirect it
+ * And that is it, no copy pasta needed: if you cannot change the project distribution management, just redirect it
  * to proper service entry in your own <code>settings.xml</code>.
  *
  * @see eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_SERVICE_REDIRECT

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
@@ -97,33 +97,64 @@ import org.eclipse.aether.repository.RemoteRepository;
  */
 public interface ArtifactPublisherRedirector {
     /**
-     * Tells, based on Njord config, what is the real URL used for given remote repository. Never returns {@code null},
+     * Tells, based on server config, what is the Njord URL to be used for given remote repository. Never returns {@code null},
      * and without any configuration just returns passed in repository URL.
+     *
+     * @param repository The remote repository we ask config for, never {@code null}.
      */
     String getRepositoryUrl(RemoteRepository repository);
 
     /**
-     * Tells, based on Njord config, what is the real URL used for given remote repository. Never returns {@code null},
+     * Tells, based on server config, what is the Njord URL to be used for given remote repository. Never returns {@code null},
      * and without any configuration just returns passed in repository URL.
+     *
+     * @param repository The remote repository we ask config for, never {@code null}.
+     * @param repositoryMode The repository mode we ask URL for, never {@code null}.
      */
     String getRepositoryUrl(RemoteRepository repository, RepositoryMode repositoryMode);
 
     /**
      * Returns the remote repository to source auth from for the passed in remote repository. Never returns {@code null}.
+     * The repository will have auth applied, if applicable.
+     *
+     * @param repository The remote repository we ask Auth for, never {@code null}.
      */
-    RemoteRepository getAuthRepositoryId(RemoteRepository repository, boolean followAuthRedirection);
+    RemoteRepository getAuthRepositoryId(RemoteRepository repository);
 
     /**
      * Returns the remote repository to use for publishing. Never returns {@code null}. The repository will have
-     * auth and any auth-redirection, if applicable, applied.
+     * auth applied, if applicable. The auth may come from elsewhere, see {@link #getAuthRepositoryId(RemoteRepository)}.
      *
-     * @see #getAuthRepositoryId(RemoteRepository, boolean)
+     * @param repository The remote repository we ask Auth for, never {@code null}.
+     * @param expectAuth Whether a warning should be logged if no auth found (is most probably configuration error).
      */
-    RemoteRepository getPublishingRepository(
-            RemoteRepository repository, boolean expectAuth, boolean followAuthRedirection);
+    RemoteRepository getPublishingRepository(RemoteRepository repository, boolean expectAuth);
 
     /**
      * Returns the name of wanted/configured {@link eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher}.
+     * This method returns present string optional ONLY if string found in configuration is name of existing publisher.
+     * If there was a string discovered, but string is not a name of existing publisher, this method throws. Otherwise,
+     * empty optional is returned. The decision is made based on
+     * {@link eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_PUBLISHER} property sourced from properties
+     * (system, user or project), and finally, if project present, the distribution management of it.
+     *
+     * @throws IllegalStateException If string was found (given or found in config) but name does not correspond to
+     *         known publisher.
      */
     Optional<String> getArtifactStorePublisherName();
+
+    /**
+     * Returns the name of wanted/configured {@link eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher}
+     * based on passed in name. This method returns present string optional ONLY if passed in name is name of existing
+     * publisher, or, is a server ID that has publisher configured. If there was a string discovered, but string is
+     * not a name of existing publisher, this method throws.
+     *
+     * @param name A "name" that may be {@code null}. If not null, it is observed as "user input" and will be used
+     *             as basis for looking up publisher name. Value may be a publisher name, or a settings server ID that has
+     *             Njord config with {@link eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_PUBLISHER}. If
+     *             name is {@code null}, call is passed to {@link #getArtifactStorePublisherName()} method.
+     * @throws IllegalStateException If string was found (given or found in config) but name does not correspond to
+     *         known publisher.
+     */
+    Optional<String> getArtifactStorePublisherName(String name);
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
@@ -25,10 +25,10 @@ import org.eclipse.aether.repository.RemoteRepository;
  * user has these entries in own <code>settings.xml</code>, publishing is set up.
  * <p>
  * Historically, each OSS project "invented" their own Server ID in the <code>project/distributionManagement</code>,
- * so today we have many server IDs in use <em>despite almost all of use one of these 4 services to publish</em>.
+ * so today we have many server IDs in use <em>despite almost all of use one of these 3 services to publish</em>.
+ * (the Sonatype ones, so 3 and not 4, as ASF projects have all this sorted out by using ASF wide Parent POM).
  * This lead to issues, when one user maintains several "namespaces" (several unrelated groupID publishing to Central),
- * as this user needs to copy-paste all these server entries with <em>same auth</em> to be able to publish. Moreover,
- * is just chaotic, as people "invented" various names for these services.
+ * as this user needs to copy-paste all these server entries with <em>same auth</em> to be able to publish.
  * <p>
  * Take for example Sonatype Central Portal setup:
  * The recommended entry in user <code>settings.xml</code> is following (replace {@code $TOKEN1} and {@code $TOKEN2} with Central Portal generated tokens):
@@ -59,16 +59,17 @@ import org.eclipse.aether.repository.RemoteRepository;
  *     </snapshotRepository>
  *   </distributionManagement>
  * }</pre>
- * This entry tells the "truth", in a way it tells exactly where it publishes, and from where the artifacts are available
+ * This entry tells the "truth", in a way it tells exactly where it publishes (URL), and it is from where the artifacts are available
  * once they are published. This latter is important, as before it was common to have some "service URL" here, that had nothing to
- * do with "published artifacts whereabouts", it was always implied. But, some tools like SBOM managers do like to have
- * this information, instead to guess them. Similarly for snapshot publishing, it is <em>same service</em>, hence
+ * do with "published artifacts whereabouts", it was always implied. But, some tools like do like to have
+ * this information, they should not guess this. Similarly for snapshot publishing, it is <em>same service</em>, hence
  * same auth is needed for it as well.
  * <p>
- * Moreover, consider if some vendor changes service endpoint (like goes V2 from V1). Having service endpoint in here
- * is not future-proof. Also, it does not express where the published artifacts go. Finally, all you do is "just publish
- * to Central", so why should POM differ from project that use service A from service B, while they both publish to
- * Central? Does it matter HOW you publish, while the WHERE you publish remain same?  Is silly.
+ * Moreover, consider if some vendor changes service endpoint (like goes Ver2 from Ver1). Having service endpoint in here
+ * is not future-proof and is just confusing: your publishing target (Central) does not change but some technicality requires
+ * you to change you parent POM. Using service endpoint does not express where the published artifacts will go.
+ * Finally, all you do is <em>publish to Central</em>, so why should POM differ between two projects, possibly using
+ * different services? Does it matter HOW you publish, while the WHERE you publish remain same? Is just silly.
  * <p>
  * Njord encourages this setup:
  * <ul>
@@ -77,8 +78,8 @@ import org.eclipse.aether.repository.RemoteRepository;
  *     <li>if not possible, it allows you to create "redirects" in your <code>settings.xml</code> to overcome this chaos</li>
  * </ul>
  * <p>
- * In case you need to publish a project that does not follow these rules, and assume it uses some invented server IDs,
- * like "the-project-releases", but in reality it wants to use Central Portal, just add this entry to your user
+ * In case you need to publish a project that does not follow these rules, and assuming it uses own invented server ID
+ * "the-project-releases", but it migrated to use Central Portal, just add this entry to your user
  * <code>settings.xml</code>:
  * <pre>{@code
  *     <server>
@@ -88,8 +89,8 @@ import org.eclipse.aether.repository.RemoteRepository;
  *       </configuration>
  *     </server>
  * }</pre>
- * And that is it: no copy pasta needed: if you cannot change the project distribution management, just reidrect it
- * to proper service.
+ * And that is it: no copy pasta needed: if you cannot change the project distribution management, just redirect it
+ * to proper service entry in your own <code>settings.xml</code>.
  *
  * @see eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_SERVICE_REDIRECT
  * @see eu.maveniverse.maven.njord.shared.SessionConfig#CONFIG_AUTH_REDIRECT

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactPublisherRedirector.java
@@ -85,7 +85,7 @@ import org.eclipse.aether.repository.RemoteRepository;
  *     <server>
  *       <id>the-project-releases</id>
  *       <configuration>
- *         <njord.redirectService>sonatype-central-portal</njord.redirectService>
+ *         <njord.serviceRedirect>sonatype-central-portal</njord.serviceRedirect>
  *       </configuration>
  *     </server>
  * }</pre>

--- a/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/DefaultArtifactPublisherRedirectorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.njord.shared.impl.publisher;
+
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.Runtime;
+import eu.maveniverse.maven.mima.context.Runtimes;
+import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.SessionConfig;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DefaultArtifactPublisherRedirectorTest extends PublisherTestSupport {
+    @Test
+    void smoke() throws IOException {
+        Runtime runtime = Runtimes.INSTANCE.getRuntime();
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withUserSettings(true)
+                .withUserSettingsXmlOverride(
+                        Paths.get("src/test/settings/smoke.xml").toAbsolutePath())
+                .build())) {
+            Session session = createSession(
+                    context,
+                    SessionConfig.defaults(context.repositorySystemSession(), context.remoteRepositories())
+                            .basedir(cwd())
+                            .build());
+            DefaultArtifactPublisherRedirector subject =
+                    new DefaultArtifactPublisherRedirector(session, context.repositorySystem());
+
+            Assertions.assertFalse(subject.getArtifactStorePublisherName().isPresent());
+            Assertions.assertTrue(subject.getArtifactStorePublisherName("sonatype-central-portal")
+                    .isPresent());
+        }
+    }
+
+    @Test
+    void serviceRedirect() throws IOException {
+        Runtime runtime = Runtimes.INSTANCE.getRuntime();
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withUserSettings(true)
+                .withUserSettingsXmlOverride(
+                        Paths.get("src/test/settings/smoke.xml").toAbsolutePath())
+                .build())) {
+            Session session = createSession(
+                    context,
+                    SessionConfig.defaults(context.repositorySystemSession(), context.remoteRepositories())
+                            .basedir(cwd())
+                            .build());
+            DefaultArtifactPublisherRedirector subject =
+                    new DefaultArtifactPublisherRedirector(session, context.repositorySystem());
+
+            Optional<String> publisher;
+
+            publisher = subject.getArtifactStorePublisherName("sonatype-central-portal");
+            Assertions.assertTrue(publisher.isPresent());
+            Assertions.assertEquals("sonatype-cp", publisher.get());
+
+            publisher = subject.getArtifactStorePublisherName("some-project-releases");
+            Assertions.assertTrue(publisher.isPresent());
+            Assertions.assertEquals("sonatype-cp", publisher.get());
+
+            publisher = subject.getArtifactStorePublisherName("just-auth-redirect");
+            Assertions.assertTrue(publisher.isPresent());
+            Assertions.assertEquals("sonatype-cp", publisher.get());
+
+            Assertions.assertThrows(
+                    IllegalArgumentException.class, () -> subject.getArtifactStorePublisherName("unconfigured"));
+        }
+    }
+
+    @Test
+    void authRedirect() throws IOException {
+        Runtime runtime = Runtimes.INSTANCE.getRuntime();
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withUserSettings(true)
+                .withUserSettingsXmlOverride(
+                        Paths.get("src/test/settings/smoke.xml").toAbsolutePath())
+                .build())) {
+            Session session = createSession(
+                    context,
+                    SessionConfig.defaults(context.repositorySystemSession(), context.remoteRepositories())
+                            .basedir(cwd())
+                            .build());
+            DefaultArtifactPublisherRedirector subject =
+                    new DefaultArtifactPublisherRedirector(session, context.repositorySystem());
+
+            RemoteRepository authSource;
+
+            // serviceRedirect
+            authSource = subject.getAuthRepositoryId(
+                    new RemoteRepository.Builder("some-project-releases", "default", "whatever").build());
+            Assertions.assertEquals("sonatype-central-portal", authSource.getId());
+            Assertions.assertNotNull(authSource.getAuthentication());
+
+            // authRedirect
+            authSource = subject.getAuthRepositoryId(
+                    new RemoteRepository.Builder("just-auth-redirect", "default", "whatever").build());
+            Assertions.assertEquals("sonatype-central-portal", authSource.getId());
+            Assertions.assertNotNull(authSource.getAuthentication());
+
+            // unconfigured
+            authSource = subject.getAuthRepositoryId(
+                    new RemoteRepository.Builder("unconfigured", "default", "whatever").build());
+            Assertions.assertEquals("unconfigured", authSource.getId());
+            Assertions.assertNull(authSource.getAuthentication());
+        }
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/PublisherTestSupport.java
+++ b/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/PublisherTestSupport.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.njord.shared.impl.publisher;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.extensions.mmr.MavenModelReader;
+import eu.maveniverse.maven.njord.shared.Session;
+import eu.maveniverse.maven.njord.shared.SessionConfig;
+import eu.maveniverse.maven.njord.shared.SessionFactory;
+import eu.maveniverse.maven.njord.shared.impl.DefaultSessionFactory;
+import eu.maveniverse.maven.njord.shared.impl.store.DefaultArtifactStoreMergerFactory;
+import eu.maveniverse.maven.njord.shared.impl.store.DefaultArtifactStoreWriterFactory;
+import eu.maveniverse.maven.njord.shared.impl.store.DefaultInternalArtifactStoreManagerFactory;
+import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
+import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisherFactory;
+import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreRequirements;
+import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreValidator;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
+import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
+import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
+import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+
+public class PublisherTestSupport {
+    protected final Map<String, ChecksumAlgorithmFactory> checksumAlgorithmFactories;
+    protected final ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector;
+
+    public PublisherTestSupport() {
+        this.checksumAlgorithmFactories = new HashMap<>();
+        this.checksumAlgorithmFactories.put(Sha1ChecksumAlgorithmFactory.NAME, new Sha1ChecksumAlgorithmFactory());
+        this.checksumAlgorithmFactories.put(Md5ChecksumAlgorithmFactory.NAME, new Md5ChecksumAlgorithmFactory());
+        this.checksumAlgorithmFactorySelector =
+                new DefaultChecksumAlgorithmFactorySelector(this.checksumAlgorithmFactories);
+    }
+
+    protected Path basedir() throws IOException {
+        Path basedir = Paths.get("target/test-base/" + getClass().getSimpleName());
+        Files.createDirectories(basedir);
+        return basedir;
+    }
+
+    protected Path userHome() throws IOException {
+        Path dir = basedir().resolve("home");
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    protected Path cwd() throws IOException {
+        Path dir = basedir().resolve("cwd");
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    protected ArtifactStorePublisher sonatypeCp() {
+        return new ArtifactStorePublisher() {
+            @Override
+            public String name() {
+                return "sonatype-cp";
+            }
+
+            @Override
+            public String description() {
+                return "The Sonatype Central Portal";
+            }
+
+            @Override
+            public Optional<RemoteRepository> targetReleaseRepository() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<RemoteRepository> targetSnapshotRepository() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<RemoteRepository> serviceReleaseRepository() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<RemoteRepository> serviceSnapshotRepository() {
+                return Optional.empty();
+            }
+
+            @Override
+            public ArtifactStoreRequirements artifactStoreRequirements() {
+                return ArtifactStoreRequirements.NONE;
+            }
+
+            @Override
+            public Optional<ArtifactStoreValidator.ValidationResult> validate(ArtifactStore artifactStore)
+                    throws IOException {
+                return Optional.empty();
+            }
+
+            @Override
+            public void publish(ArtifactStore artifactStore) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    protected Session createSession(Context context, SessionConfig config) {
+        requireNonNull(config);
+        HashMap<String, ArtifactStorePublisherFactory> publishers = new HashMap<>();
+        publishers.put("sonatype-cp", c -> sonatypeCp());
+        SessionFactory factory = new DefaultSessionFactory(
+                new DefaultInternalArtifactStoreManagerFactory(checksumAlgorithmFactorySelector),
+                new DefaultArtifactStoreWriterFactory(),
+                new DefaultArtifactStoreMergerFactory(context.repositorySystem(), checksumAlgorithmFactorySelector),
+                new DefaultArtifactPublisherRedirectorFactory(context.repositorySystem()),
+                publishers,
+                Collections.emptyMap(),
+                new MavenModelReader(context).getImpl());
+        return factory.create(config);
+    }
+
+    protected RemoteRepository njordRemoteRepository() {
+        return new RemoteRepository.Builder("njord", "default", "njord:").build();
+    }
+
+    protected ArtifactStore artifactStore(RemoteRepository repository, Artifact... artifacts) {
+        Instant now = Instant.now();
+        Map<String, Artifact> contents =
+                Arrays.stream(artifacts).collect(Collectors.toMap(ArtifactIdUtils::toId, a -> a));
+        return new ArtifactStore() {
+            @Override
+            public String name() {
+                return "test";
+            }
+
+            @Override
+            public ArtifactStoreTemplate template() {
+                return ArtifactStoreTemplate.RELEASE_SCA;
+            }
+
+            @Override
+            public Instant created() {
+                return now;
+            }
+
+            @Override
+            public RepositoryMode repositoryMode() {
+                return RepositoryMode.RELEASE;
+            }
+
+            @Override
+            public boolean allowRedeploy() {
+                return false;
+            }
+
+            @Override
+            public List<ChecksumAlgorithmFactory> checksumAlgorithmFactories() {
+                return Collections.singletonList(new Sha1ChecksumAlgorithmFactory());
+            }
+
+            @Override
+            public List<String> omitChecksumsForExtensions() {
+                return Collections.singletonList(".asc");
+            }
+
+            @Override
+            public Optional<Artifact> originProjectArtifact() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<Artifact> artifacts() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Collection<Metadata> metadata() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public boolean artifactPresent(Artifact artifact) throws IOException {
+                return contents.containsKey(ArtifactIdUtils.toId(artifact));
+            }
+
+            @Override
+            public boolean metadataPresent(Metadata metadata) throws IOException {
+                return false;
+            }
+
+            @Override
+            public Optional<InputStream> artifactContent(Artifact artifact) throws IOException {
+                Artifact c = contents.get(ArtifactIdUtils.toId(artifact));
+                if (c != null) {
+                    return Optional.of(Files.newInputStream(c.getFile().toPath()));
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<InputStream> metadataContent(Metadata metadata) throws IOException {
+                return Optional.empty();
+            }
+
+            @Override
+            public RepositorySystemSession storeRepositorySession(RepositorySystemSession session) {
+                return session;
+            }
+
+            @Override
+            public RemoteRepository storeRemoteRepository() {
+                return repository;
+            }
+
+            @Override
+            public void writeTo(Path directory) throws IOException {
+                throw new RuntimeException("not implemented");
+            }
+
+            @Override
+            public Operation put(Collection<Artifact> artifacts, Collection<Metadata> metadata) throws IOException {
+                throw new RuntimeException("not implemented");
+            }
+
+            @Override
+            public void close() throws IOException {}
+        };
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/ValidatorTestSupport.java
+++ b/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/basic/ValidatorTestSupport.java
@@ -9,96 +9,21 @@ package eu.maveniverse.maven.njord.shared.impl.publisher.basic;
 
 import static java.util.Objects.requireNonNull;
 
-import eu.maveniverse.maven.mima.context.Context;
-import eu.maveniverse.maven.mima.extensions.mmr.MavenModelReader;
-import eu.maveniverse.maven.njord.shared.Session;
-import eu.maveniverse.maven.njord.shared.SessionConfig;
-import eu.maveniverse.maven.njord.shared.SessionFactory;
-import eu.maveniverse.maven.njord.shared.impl.DefaultSessionFactory;
 import eu.maveniverse.maven.njord.shared.impl.J8Utils;
-import eu.maveniverse.maven.njord.shared.impl.publisher.DefaultArtifactPublisherRedirectorFactory;
-import eu.maveniverse.maven.njord.shared.impl.store.DefaultArtifactStoreMergerFactory;
-import eu.maveniverse.maven.njord.shared.impl.store.DefaultArtifactStoreWriterFactory;
-import eu.maveniverse.maven.njord.shared.impl.store.DefaultInternalArtifactStoreManagerFactory;
+import eu.maveniverse.maven.njord.shared.impl.publisher.PublisherTestSupport;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStoreValidator;
 import eu.maveniverse.maven.njord.shared.publisher.spi.ValidationContext;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.njord.shared.store.ArtifactStoreTemplate;
-import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
-import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
-import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
-import org.eclipse.aether.metadata.Metadata;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
-import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
-import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 
-public class ValidatorTestSupport {
+public class ValidatorTestSupport extends PublisherTestSupport {
     protected final Path withClasses = Paths.get("src/test/binaries/validators/withClasses.jar");
     protected final Path withoutClasses = Paths.get("src/test/binaries/validators/withoutClasses.jar");
     protected final Path withSources = Paths.get("src/test/binaries/validators/withSources.jar");
     protected final Path withoutSources = Paths.get("src/test/binaries/validators/withoutSources.jar");
-
-    protected final Map<String, ChecksumAlgorithmFactory> checksumAlgorithmFactories;
-    protected final ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector;
-
-    public ValidatorTestSupport() {
-        this.checksumAlgorithmFactories = new HashMap<>();
-        this.checksumAlgorithmFactories.put(Sha1ChecksumAlgorithmFactory.NAME, new Sha1ChecksumAlgorithmFactory());
-        this.checksumAlgorithmFactories.put(Md5ChecksumAlgorithmFactory.NAME, new Md5ChecksumAlgorithmFactory());
-        this.checksumAlgorithmFactorySelector =
-                new DefaultChecksumAlgorithmFactorySelector(this.checksumAlgorithmFactories);
-    }
-
-    protected Path basedir() throws IOException {
-        Path basedir = Paths.get("target/test-base/" + getClass().getSimpleName());
-        Files.createDirectories(basedir);
-        return basedir;
-    }
-
-    protected Path userHome() throws IOException {
-        Path dir = basedir().resolve("home");
-        Files.createDirectories(dir);
-        return dir;
-    }
-
-    protected Path cwd() throws IOException {
-        Path dir = basedir().resolve("cwd");
-        Files.createDirectories(dir);
-        return dir;
-    }
-
-    protected Session createSession(Context context, SessionConfig config) {
-        requireNonNull(config);
-        SessionFactory factory = new DefaultSessionFactory(
-                new DefaultInternalArtifactStoreManagerFactory(checksumAlgorithmFactorySelector),
-                new DefaultArtifactStoreWriterFactory(),
-                new DefaultArtifactStoreMergerFactory(context.repositorySystem(), checksumAlgorithmFactorySelector),
-                new DefaultArtifactPublisherRedirectorFactory(context.repositorySystem()),
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                new MavenModelReader(context).getImpl());
-        return factory.create(config);
-    }
 
     public static class TestValidationContext implements ArtifactStoreValidator.ValidationResult, ValidationContext {
         private final String name;
@@ -161,113 +86,5 @@ public class ValidatorTestSupport {
             children.put(name, child);
             return child;
         }
-    }
-
-    protected RemoteRepository njordRemoteRepository() {
-        return new RemoteRepository.Builder("njord", "default", "njord:").build();
-    }
-
-    protected ArtifactStore artifactStore(RemoteRepository repository, Artifact... artifacts) {
-        Instant now = Instant.now();
-        Map<String, Artifact> contents =
-                Arrays.stream(artifacts).collect(Collectors.toMap(ArtifactIdUtils::toId, a -> a));
-        return new ArtifactStore() {
-            @Override
-            public String name() {
-                return "test";
-            }
-
-            @Override
-            public ArtifactStoreTemplate template() {
-                return ArtifactStoreTemplate.RELEASE_SCA;
-            }
-
-            @Override
-            public Instant created() {
-                return now;
-            }
-
-            @Override
-            public RepositoryMode repositoryMode() {
-                return RepositoryMode.RELEASE;
-            }
-
-            @Override
-            public boolean allowRedeploy() {
-                return false;
-            }
-
-            @Override
-            public List<ChecksumAlgorithmFactory> checksumAlgorithmFactories() {
-                return Collections.singletonList(new Sha1ChecksumAlgorithmFactory());
-            }
-
-            @Override
-            public List<String> omitChecksumsForExtensions() {
-                return Collections.singletonList(".asc");
-            }
-
-            @Override
-            public Optional<Artifact> originProjectArtifact() {
-                return Optional.empty();
-            }
-
-            @Override
-            public Collection<Artifact> artifacts() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public Collection<Metadata> metadata() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public boolean artifactPresent(Artifact artifact) throws IOException {
-                return contents.containsKey(ArtifactIdUtils.toId(artifact));
-            }
-
-            @Override
-            public boolean metadataPresent(Metadata metadata) throws IOException {
-                return false;
-            }
-
-            @Override
-            public Optional<InputStream> artifactContent(Artifact artifact) throws IOException {
-                Artifact c = contents.get(ArtifactIdUtils.toId(artifact));
-                if (c != null) {
-                    return Optional.of(Files.newInputStream(c.getFile().toPath()));
-                }
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<InputStream> metadataContent(Metadata metadata) throws IOException {
-                return Optional.empty();
-            }
-
-            @Override
-            public RepositorySystemSession storeRepositorySession(RepositorySystemSession session) {
-                return session;
-            }
-
-            @Override
-            public RemoteRepository storeRemoteRepository() {
-                return repository;
-            }
-
-            @Override
-            public void writeTo(Path directory) throws IOException {
-                throw new RuntimeException("not implemented");
-            }
-
-            @Override
-            public Operation put(Collection<Artifact> artifacts, Collection<Metadata> metadata) throws IOException {
-                throw new RuntimeException("not implemented");
-            }
-
-            @Override
-            public void close() throws IOException {}
-        };
     }
 }

--- a/core/src/test/settings/smoke.xml
+++ b/core/src/test/settings/smoke.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0">
+
+  <servers>
+    <server>
+      <id>sonatype-central-portal</id>
+      <username>token1</username>
+      <password>token2</password>
+      <configuration>
+        <njord.publisher>sonatype-cp</njord.publisher>
+        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+      </configuration>
+    </server>
+    <server>
+      <id>some-project-releases</id>
+      <configuration>
+        <njord.serviceRedirect>sonatype-central-portal</njord.serviceRedirect>
+      </configuration>
+    </server>
+    <server>
+      <id>just-auth-redirect</id>
+      <configuration>
+        <njord.authRedirect>sonatype-central-portal</njord.authRedirect>
+        <njord.publisher>sonatype-cp</njord.publisher>
+        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+      </configuration>
+    </server>
+    <server>
+      <id>unconfigured</id>
+    </server>
+  </servers>
+</settings>

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
@@ -37,8 +37,8 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
     protected String store;
 
     /**
-     * The name of the publisher to publish to. If not given, Njord will try to figure it out: it will look in
-     * user properties, project properties (if available) and user Settings server configuration.
+     * The name of the publisher or service/server ID to publish to. If not given, Njord will try to figure it out:
+     * it will look in user properties, project properties (if available) and user Settings server configuration.
      * <p>
      * This "heuristic" will work only if there is current project. While invoking mojo is possible outside a
      * project as well (validate and publish mojos does not require project), in such cases this parameter is

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/PublisherSupportMojo.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.njord.plugin3;
 import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.impl.J8Utils;
+import eu.maveniverse.maven.njord.shared.publisher.ArtifactPublisherRedirector;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
 import java.io.IOException;
@@ -99,19 +100,10 @@ public abstract class PublisherSupportMojo extends NjordMojoSupport {
     }
 
     /**
-     * Returns publisher name, if possible.
-     * <ul>
-     *     <li>if {@code publisher} parameter is set, is returned</li>
-     *     <li>if {@link SessionConfig#publisher()} is present (so is set in user or project properties, if project is available), is returned</li>
-     *     <li>if there is project available, distribution management repository ID is checked is it publisher name, if yes, is returned</li>
-     *     <li>if there is configuration in settings for distribution management repository ID server, it is checked and if configuration exists, is returned</li>
-     * </ul>
+     * Returns publisher name, if possible. Uses {@link ArtifactPublisherRedirector#getArtifactStorePublisherName(String)}.
      */
     protected Optional<String> getArtifactStorePublisherName(Session ns) {
-        if (publisher != null) {
-            return Optional.of(publisher);
-        }
-        return ns.artifactPublisherRedirector().getArtifactStorePublisherName();
+        return ns.artifactPublisherRedirector().getArtifactStorePublisherName(publisher);
     }
 
     protected ArtifactStorePublisher getArtifactStorePublisher(Session ns) throws MojoFailureException {

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/StatusMojo.java
@@ -59,7 +59,7 @@ public class StatusMojo extends PublisherSupportMojo {
         logger.info("* Release");
         logger.info("  Repository Id: {}", deploymentRelease.getId());
         RemoteRepository releaseAuthSource =
-                ns.artifactPublisherRedirector().getPublishingRepository(deploymentRelease, false, true);
+                ns.artifactPublisherRedirector().getPublishingRepository(deploymentRelease, false);
         if (!Objects.equals(releaseAuthSource.getId(), deploymentRelease.getId())) {
             logger.info("  Auth source Id: {}", releaseAuthSource.getId());
         }
@@ -80,7 +80,7 @@ public class StatusMojo extends PublisherSupportMojo {
         logger.info("* Snapshot");
         logger.info("  Repository Id: {}", deploymentSnapshot.getId());
         RemoteRepository snapshotAuthSource =
-                ns.artifactPublisherRedirector().getPublishingRepository(deploymentSnapshot, false, true);
+                ns.artifactPublisherRedirector().getPublishingRepository(deploymentSnapshot, false);
         if (!Objects.equals(snapshotAuthSource.getId(), deploymentSnapshot.getId())) {
             logger.info("  Auth source Id: {}", snapshotAuthSource.getId());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,9 @@
 
     <!-- Dependency versions -->
     <version.maveniverseShared>0.1.8</version.maveniverseShared>
-    <version.maven>3.9.9</version.maven>
+    <version.maven>3.9.10</version.maven>
     <version.resolver>1.9.23</version.resolver>
-    <version.mima>2.4.28</version.mima>
+    <version.mima>2.4.29</version.mima>
     <version.slf4j>1.7.36</version.slf4j>
   </properties>
 

--- a/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisher.java
+++ b/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisher.java
@@ -19,15 +19,12 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.RemoteRepository;
 
 public class DeployPublisher extends ArtifactStorePublisherSupport {
-    private final boolean followAuthRedirection;
-
     public DeployPublisher(
             Session session,
             RepositorySystem repositorySystem,
             RemoteRepository releasesRepository,
             RemoteRepository snapshotsRepository,
-            ArtifactStoreRequirements artifactStoreRequirements,
-            boolean followAuthRedirection) {
+            ArtifactStoreRequirements artifactStoreRequirements) {
         super(
                 session,
                 repositorySystem,
@@ -38,7 +35,6 @@ public class DeployPublisher extends ArtifactStorePublisherSupport {
                 releasesRepository,
                 snapshotsRepository,
                 artifactStoreRequirements);
-        this.followAuthRedirection = followAuthRedirection;
     }
 
     @Override
@@ -55,8 +51,7 @@ public class DeployPublisher extends ArtifactStorePublisherSupport {
                             repositorySystem,
                             new DefaultRepositorySystemSession(session.config().session())
                                     .setConfigProperty(NjordUtils.RESOLVER_SESSION_CONNECTOR_SKIP, true),
-                            session.artifactPublisherRedirector()
-                                    .getPublishingRepository(repository, true, followAuthRedirection),
+                            session.artifactPublisherRedirector().getPublishingRepository(repository, true),
                             true)
                     .deploy(store);
         }

--- a/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
+++ b/publisher/deploy/src/main/java/eu/maveniverse/maven/njord/publisher/deploy/DeployPublisherFactory.java
@@ -43,7 +43,6 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
     public static final String NAME = "deploy";
 
     private static final String PROP_ALT_DEPLOYMENT_REPOSITORY = "altDeploymentRepository";
-    private static final String PROP_ALT_DEPLOYMENT_REPOSITORY_AUTH_REDIRECT = "altDeploymentRepositoryAuthRedirect";
 
     private final RepositorySystem repositorySystem;
 
@@ -58,7 +57,6 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
 
         RemoteRepository releasesRepository = null;
         RemoteRepository snapshotsRepository = null;
-        boolean followAuthRedirection = true;
         if (session.config().effectiveProperties().containsKey(PROP_ALT_DEPLOYMENT_REPOSITORY)) {
             String altDeploymentRepository =
                     session.config().effectiveProperties().get(PROP_ALT_DEPLOYMENT_REPOSITORY);
@@ -75,11 +73,6 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
             snapshotsRepository = new RemoteRepository.Builder(id, "default", url)
                     .setReleasePolicy(new RepositoryPolicy(false, null, null))
                     .build();
-            followAuthRedirection = Boolean.parseBoolean(session.config()
-                    .effectiveProperties()
-                    .getOrDefault(
-                            PROP_ALT_DEPLOYMENT_REPOSITORY_AUTH_REDIRECT,
-                            "false")); // user specified explicitly what he wants here, but may override it
         } else if (session.config().currentProject().isPresent()) {
             SessionConfig.CurrentProject project =
                     session.config().currentProject().orElseThrow(J8Utils.OET);
@@ -88,11 +81,6 @@ public class DeployPublisherFactory implements ArtifactStorePublisherFactory {
         }
 
         return new DeployPublisher(
-                session,
-                repositorySystem,
-                releasesRepository,
-                snapshotsRepository,
-                ArtifactStoreRequirements.NONE,
-                followAuthRedirection);
+                session, repositorySystem, releasesRepository, snapshotsRepository, ArtifactStoreRequirements.NONE);
     }
 }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeCentralPortalPublisher.java
@@ -94,12 +94,10 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
 
                 // build auth token
                 RemoteRepository authSource =
-                        session.artifactPublisherRedirector().getAuthRepositoryId(repository, true);
+                        session.artifactPublisherRedirector().getAuthRepositoryId(repository);
                 String authValue = null;
-                try (AuthenticationContext repoAuthContext = AuthenticationContext.forRepository(
-                        session.config().session(),
-                        repositorySystem.newDeploymentRepository(
-                                session.config().session(), authSource))) {
+                try (AuthenticationContext repoAuthContext =
+                        AuthenticationContext.forRepository(session.config().session(), authSource)) {
                     if (repoAuthContext != null) {
                         String username = repoAuthContext.get(AuthenticationContext.USERNAME);
                         String password = repoAuthContext.get(AuthenticationContext.PASSWORD);
@@ -178,7 +176,7 @@ public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSuppor
                                 new DefaultRepositorySystemSession(
                                                 session.config().session())
                                         .setConfigProperty(NjordUtils.RESOLVER_SESSION_CONNECTOR_SKIP, true),
-                                session.artifactPublisherRedirector().getPublishingRepository(repository, true, true),
+                                session.artifactPublisherRedirector().getPublishingRepository(repository, true),
                                 true)
                         .deploy(store);
             }

--- a/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeNx2Publisher.java
+++ b/publisher/sonatype/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/SonatypeNx2Publisher.java
@@ -54,7 +54,7 @@ public class SonatypeNx2Publisher extends ArtifactStorePublisherSupport {
                         repositorySystem,
                         new DefaultRepositorySystemSession(session.config().session())
                                 .setConfigProperty(NjordUtils.RESOLVER_SESSION_CONNECTOR_SKIP, true),
-                        session.artifactPublisherRedirector().getPublishingRepository(repository, true, true),
+                        session.artifactPublisherRedirector().getPublishingRepository(repository, true),
                         true)
                 .deploy(artifactStore);
     }


### PR DESCRIPTION
This PR updates to latest Maven 3.9.10 and MIMA 2.4.29 aligning them finally.

But, the main reason is to refactor settings management, document and clean it up. Also, added UTs explaining what the intent and possibilities are.