### PR TITLE
Improve configuration handling

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisher.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisher.java
@@ -24,6 +24,11 @@ public interface ArtifactStorePublisher {
     String description();
 
     /**
+     * Returns {@code true} if this publisher is configured and is usable.
+     */
+    boolean isConfigured();
+
+    /**
      * The remote repository where release artifacts will become available after publishing succeeded.
      */
     Optional<RemoteRepository> targetReleaseRepository();

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisherSupport.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/publisher/ArtifactStorePublisherSupport.java
@@ -62,6 +62,11 @@ public abstract class ArtifactStorePublisherSupport extends ComponentSupport imp
     }
 
     @Override
+    public boolean isConfigured() {
+        return serviceReleaseRepository != null || targetReleaseRepository != null;
+    }
+
+    @Override
     public Optional<RemoteRepository> targetReleaseRepository() {
         return Optional.ofNullable(targetReleaseRepository);
     }
@@ -120,7 +125,7 @@ public abstract class ArtifactStorePublisherSupport extends ComponentSupport imp
                 : serviceSnapshotRepository;
         if (repository == null) {
             throw new IllegalArgumentException("Repository mode " + artifactStore.repositoryMode()
-                    + " not supported; provide RemoteRepository for it");
+                    + " not supported; configure RemoteRepository for it");
         }
         return repository;
     }

--- a/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/PublisherTestSupport.java
+++ b/core/src/test/java/eu/maveniverse/maven/njord/shared/impl/publisher/PublisherTestSupport.java
@@ -93,6 +93,11 @@ public class PublisherTestSupport {
             }
 
             @Override
+            public boolean isConfigured() {
+                return false;
+            }
+
+            @Override
             public Optional<RemoteRepository> targetReleaseRepository() {
                 return Optional.empty();
             }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/NjordMojoSupport.java
@@ -152,6 +152,7 @@ public abstract class NjordMojoSupport extends MojoSupport {
                 "    RELEASES:  {}", fmt(publisher.serviceReleaseRepository().orElse(null)));
         logger.info(
                 "    SNAPSHOTS: {}", fmt(publisher.serviceSnapshotRepository().orElse(null)));
+        logger.info("  Operational state: {}", publisher.isConfigured() ? "Configured" : "Not configured");
     }
 
     private String fmt(RemoteRepository repo) {

--- a/publisher/sonatype-nx2/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/nx2/SonatypeNx2PublisherConfig.java
+++ b/publisher/sonatype-nx2/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/nx2/SonatypeNx2PublisherConfig.java
@@ -18,9 +18,9 @@ import eu.maveniverse.maven.njord.shared.store.RepositoryMode;
  * Properties supported (note: at least the URLs must be provided as defaults are most probably wrong):
  * <ul>
  *     <li><code>njord.publisher.sonatype-nx2.releaseRepositoryId</code> - the release service server.id (default "releases")</li>
- *     <li><code>njord.publisher.sonatype-nx2.releaseRepositoryUrl</code> - the release service URL <em>(default to http://localhost:8081/content/repositories/releases/)</em></li>
+ *     <li><code>njord.publisher.sonatype-nx2.releaseRepositoryUrl</code> - the release service URL <em>(mandatory; without setting it publisher cannot publish releases)</em></li>
  *     <li><code>njord.publisher.sonatype-nx2.snapshotRepositoryId</code> - the snapshot service server.id (default "snapshots")</li>
- *     <li><code>njord.publisher.sonatype-nx2.snapshotRepositoryUrl</code> - the snapshot service URL <em>(default to http://localhost:8081/content/repositories/snapshots/)</em></li>
+ *     <li><code>njord.publisher.sonatype-nx2.snapshotRepositoryUrl</code> - the snapshot service URL <em>(mandatory; without setting it publisher cannot publish snapshots)</em></li>
  *     <li><code>njord.publisher.sonatype-nx2.artifactStoreRequirements</code> - the requirements deployment must fulfil (defaults to NONE)</li>
  * </ul>
  */
@@ -34,15 +34,11 @@ public final class SonatypeNx2PublisherConfig extends PublisherConfig {
                 repositoryId(sessionConfig, RepositoryMode.RELEASE, "releases"),
                 sessionConfig
                         .effectiveProperties()
-                        .getOrDefault(
-                                keyName(SonatypeNx2PublisherFactory.NAME, "releaseRepositoryUrl"),
-                                "http://localhost:8081/content/repositories/releases/"),
+                        .get(keyName(SonatypeNx2PublisherFactory.NAME, "releaseRepositoryUrl")),
                 repositoryId(sessionConfig, RepositoryMode.SNAPSHOT, "snapshots"),
                 sessionConfig
                         .effectiveProperties()
-                        .getOrDefault(
-                                keyName(SonatypeNx2PublisherFactory.NAME, "snapshotRepositoryUrl"),
-                                "http://localhost:8081/content/repositories/snapshots/"));
+                        .get(keyName(SonatypeNx2PublisherFactory.NAME, "snapshotRepositoryUrl")));
         this.artifactStoreRequirements = sessionConfig
                 .effectiveProperties()
                 .getOrDefault(


### PR DESCRIPTION
Just as `deploy` had, we in fact allow "empty" configuration, apply same logic to new `sonatype-nx2` too. Config allows `null` config fields, so let use them then to signal "unconfigured" state.