### PR TITLE
Using https://central.sonatype.com/publishing/deployments leads to a 400

### DIFF
--- a/publisher/sonatype-cp/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/cp/SonatypeCentralPortalPublisher.java
+++ b/publisher/sonatype-cp/src/main/java/eu/maveniverse/maven/njord/publisher/sonatype/cp/SonatypeCentralPortalPublisher.java
@@ -48,7 +48,7 @@ import org.eclipse.aether.util.ConfigUtils;
 import org.json.JSONObject;
 
 public class SonatypeCentralPortalPublisher extends ArtifactStorePublisherSupport {
-    private static final String CENTRAL_DEPLOYMENTS_URL = "https://central.sonatype.com/publishing/deployments";
+    private static final String CENTRAL_DEPLOYMENTS_URL = "https://central.sonatype.com/publishing";
     private final SonatypeCentralPortalPublisherConfig publisherConfig;
     private final MavenHttpClient4FactoryImpl mhc4;
 


### PR DESCRIPTION
status when not yet logged in

Use https://central.sonatype.com/publishing instead which should end up on the same page.