### PR TITLE
Fix ClassCastException in mvnd when extension ClassRealm is reloaded

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordUtils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordUtils.java
@@ -47,4 +47,9 @@ public final class NjordUtils {
         Object value = repositorySystemSession.getData().get(Session.class);
         return value instanceof Session ? Optional.of((Session) value) : Optional.empty();
     }
+
+    public static synchronized void removeNjordSession(RepositorySystemSession repositorySystemSession) {
+        requireNonNull(repositorySystemSession, "repositorySystemSession");
+        repositorySystemSession.getData().set(Session.class, null);
+    }
 }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordUtils.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/NjordUtils.java
@@ -29,10 +29,12 @@ public final class NjordUtils {
     public static synchronized Session lazyInit(RepositorySystemSession session, Supplier<Session> sessionFactory) {
         requireNonNull(session, "session");
         requireNonNull(sessionFactory, "sessionFactory");
-        Session s = (Session) session.getData().get(Session.class.getName());
+        // Key by class object for isolation between class loaders (ClassRealms)
+        Object existing = session.getData().get(Session.class);
+        Session s = existing instanceof Session ? (Session) existing : null;
         if (s == null) {
             s = sessionFactory.get();
-            session.getData().set(Session.class.getName(), s);
+            session.getData().set(Session.class, s);
         }
         return s;
     }
@@ -42,6 +44,7 @@ public final class NjordUtils {
      */
     public static synchronized Optional<Session> mayGetNjordSession(RepositorySystemSession repositorySystemSession) {
         requireNonNull(repositorySystemSession, "repositorySystemSession");
-        return Optional.ofNullable((Session) repositorySystemSession.getData().get(Session.class.getName()));
+        Object value = repositorySystemSession.getData().get(Session.class);
+        return value instanceof Session ? Optional.of((Session) value) : Optional.empty();
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
@@ -25,6 +25,7 @@ import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.execution.MavenSession;
+import org.eclipse.aether.RepositorySystemSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,8 +73,9 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
     @Override
     public void afterSessionEnd(MavenSession session) throws MavenExecutionException {
         requireNonNull(session);
+        RepositorySystemSession repositorySession = session.getRepositorySession();
         try {
-            Optional<Session> ns = NjordUtils.mayGetNjordSession(session.getRepositorySession());
+            Optional<Session> ns = NjordUtils.mayGetNjordSession(repositorySession);
             if (ns.isPresent()) {
                 try (Session njordSession = ns.orElseThrow(J8Utils.OET)) {
                     if (njordSession.config().autoPublish()) {
@@ -118,6 +120,8 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
             }
         } catch (IOException e) {
             throw new MavenExecutionException("Error closing Njord", e);
+        } finally {
+            NjordUtils.removeNjordSession(repositorySession);
         }
     }
 }


### PR DESCRIPTION
mvnd (Maven Daemon) caches extension ClassRealms across builds.  When the njord extension JAR is updated mid-session (e.g. parent POM upgrade bumps the version), mvnd creates a fresh ClassRealm for the new JAR but leaves Plexus singletons from the stale ClassRealm registered in the container.  The stale NjordRepositoryConnectorFactory then tries to cast a Session object that was created by the new ClassRealm's lifecycle participant into its own ClassRealm's Session type, throwing:

    ClassCastException: DefaultSession (loader ClassRealm @A)
        cannot be cast to Session (loader ClassRealm @B)

Root cause: both ClassRealms key their session data entry with the same String "eu.maveniverse.maven.njord.shared.Session", so the stale realm finds — and attempts to cast — the other realm's object.

Fix: use Session.class (the Class *object*) as the session data key instead of Session.class.getName() (a String).  Class objects are ClassRealm-local: each realm has its own Session.class instance, so realms have independent, non-interfering session data slots. The instanceof guard makes both methods safe even if the entry was somehow populated by a foreign object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal session caching so stored session instances are handled more robustly and isolated, reducing accidental reuse of invalid cached values.

* **Bug Fix**
  * Ensure session state is always cleared when a lifecycle ends (including on errors) to prevent stale session data from lingering in repository state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->