### PR TITLE
WriteBundleMojo to support file as a target

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStoreWriter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/store/DefaultArtifactStoreWriter.java
@@ -37,14 +37,30 @@ public class DefaultArtifactStoreWriter extends ComponentSupport implements Arti
 
     @Override
     public Path writeAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException {
-        requireNonNull(artifactStore);
-        requireNonNull(outputDirectory);
+        return writeAsBundle(artifactStore, outputDirectory, false);
+    }
 
-        Path targetDirectory = FileUtils.canonicalPath(outputDirectory);
-        if (!Files.isDirectory(targetDirectory)) {
-            Files.createDirectories(targetDirectory);
+    @Override
+    public Path writeAsBundle(ArtifactStore artifactStore, Path output, boolean outputMayBeFile) throws IOException {
+        requireNonNull(artifactStore);
+        requireNonNull(output);
+
+        Path target = FileUtils.canonicalPath(output);
+        Path bundleFile;
+        if (!outputMayBeFile || Files.isDirectory(target)) {
+            // directory semantics: write <target>/<store name>.zip
+            if (!Files.isDirectory(target)) {
+                Files.createDirectories(target);
+            }
+            bundleFile = target.resolve(artifactStore.name() + ".zip");
+        } else {
+            // file semantics: write to the exact file, creating missing parent directories
+            bundleFile = target;
+            Path parent = bundleFile.getParent();
+            if (parent != null && !Files.isDirectory(parent)) {
+                Files.createDirectories(parent);
+            }
         }
-        Path bundleFile = targetDirectory.resolve(artifactStore.name() + ".zip");
         if (Files.exists(bundleFile)) {
             throw new IOException("Exporting to existing bundle ZIP not supported");
         }

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreWriter.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/store/ArtifactStoreWriter.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.njord.shared.store;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public interface ArtifactStoreWriter {
@@ -17,7 +18,24 @@ public interface ArtifactStoreWriter {
     Path writeAsDirectory(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
 
     /**
-     * Exports store as ZIP bundle. Returns the ZIP file.
+     * Writes the store as a ZIP bundle named {@code <store name>.zip} into the given directory. Returns the ZIP file.
      */
     Path writeAsBundle(ArtifactStore artifactStore, Path outputDirectory) throws IOException;
+
+    /**
+     * Like {@link #writeAsBundle(ArtifactStore, Path)}, but lets you choose the exact output file. When
+     * {@code outputMayBeFile} is {@code true} and {@code output} is not an existing directory, the bundle is written
+     * to that file (creating parent directories if needed); otherwise {@code output} is used as the target directory.
+     * Returns the ZIP file.
+     * <p>
+     * The default implementation only handles the directory case; implementations that can write to a specific file
+     * override it.
+     */
+    default Path writeAsBundle(ArtifactStore artifactStore, Path output, boolean outputMayBeFile) throws IOException {
+        if (!outputMayBeFile || Files.isDirectory(output)) {
+            return writeAsBundle(artifactStore, output);
+        }
+        throw new UnsupportedOperationException(
+                "Writing a bundle to an explicit file is not supported by this ArtifactStoreWriter implementation");
+    }
 }

--- a/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteBundleMojo.java
+++ b/plugin/src/main/java/eu/maveniverse/maven/njord/plugin3/WriteBundleMojo.java
@@ -11,48 +11,74 @@ import eu.maveniverse.maven.njord.shared.Session;
 import eu.maveniverse.maven.njord.shared.SessionConfig;
 import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.store.ArtifactStore;
-import eu.maveniverse.maven.shared.core.fs.FileUtils;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * Write out a store as "bundle" ZIP to given path. The ZIP file has remote repository layout and contains all the
- * artifacts and metadata.
+ * Write out a store as "bundle" ZIP. The ZIP file has remote repository layout and contains all the artifacts and
+ * metadata.
+ * <p>
+ * If the {@code store} parameter is not given, the latest (newest) store staged by the current project is used. The
+ * bundle may be written into a directory (parameter {@code directory}, using {@code <store name>.zip} as file name),
+ * or to an exact file (parameter {@code file}).
  */
 @Mojo(name = "write-bundle", threadSafe = true, requiresProject = false, aggregator = true)
 public class WriteBundleMojo extends NjordMojoSupport {
     /**
-     * The name of the store to be written out.
+     * The name of the store to be written out. If not given, the latest (newest) store staged by the current
+     * project is used.
      */
-    @Parameter(required = true, property = SessionConfig.KEY_PREFIX + "store")
+    @Parameter(property = SessionConfig.KEY_PREFIX + "store")
     private String store;
 
     /**
-     * The directory to write out the bundle file.
+     * The directory to write out the bundle file into; the bundle file will be named {@code <store name>.zip}.
+     * Ignored when {@link #file} is set. Either this or {@link #file} must be set.
      */
-    @Parameter(required = true, property = SessionConfig.KEY_PREFIX + "directory")
+    @Parameter(property = SessionConfig.KEY_PREFIX + "directory")
     private String directory;
+
+    /**
+     * The exact file to write out the bundle to. Takes precedence over {@link #directory}; any missing parent
+     * directories are created. Either this or {@link #directory} must be set.
+     */
+    @Parameter(property = SessionConfig.KEY_PREFIX + "file")
+    private String file;
 
     @Override
     protected void doWithSession(Session ns) throws IOException, MojoExecutionException {
-        Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(store);
-        if (storeOptional.isPresent()) {
-            Path targetDirectory = FileUtils.canonicalPath(Paths.get(directory).toAbsolutePath());
-            if (!Files.isDirectory(targetDirectory)) {
-                Files.createDirectories(targetDirectory);
+        if ((file == null || file.isEmpty()) && directory == null) {
+            throw new MojoExecutionException("One of 'file' or 'directory' parameters must be set");
+        }
+        String storeName = store;
+        if (storeName == null && ns.config().prefix().isPresent()) {
+            List<String> candidates = ns.artifactStoreManager()
+                    .listArtifactStoreNamesForPrefix(ns.config().prefix().orElseThrow(J8Utils.OET));
+            if (!candidates.isEmpty()) {
+                storeName = candidates.get(candidates.size() - 1);
+                logger.info("No store specified; using latest staged store '{}'", storeName);
             }
-            logger.info("Writing store {} as bundle to {}", store, directory);
-            Path result =
-                    ns.artifactStoreWriter().writeAsBundle(storeOptional.orElseThrow(J8Utils.OET), targetDirectory);
-            logger.info("Written to " + result);
+        }
+        if (storeName == null) {
+            logger.warn("ArtifactStore not specified and none could be found");
+            return;
+        }
+        Optional<ArtifactStore> storeOptional = ns.artifactStoreManager().selectArtifactStore(storeName);
+        if (storeOptional.isPresent()) {
+            try (ArtifactStore artifactStore = storeOptional.orElseThrow(J8Utils.OET)) {
+                Path output = (file != null ? Paths.get(file) : Paths.get(directory)).toAbsolutePath();
+                logger.info("Writing store {} as bundle to {}", artifactStore.name(), output);
+                Path result = ns.artifactStoreWriter().writeAsBundle(artifactStore, output, file != null);
+                logger.info("Written to " + result);
+            }
         } else {
-            logger.warn("ArtifactStore with given name not found");
+            logger.warn("ArtifactStore with given name not found: {}", storeName);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle export can now target either an explicit ZIP **file path** or a **directory** destination.
  * Providing `store` is now optional; if omitted, the bundle uses the latest staged store name from the configured prefix.
* **Bug Fixes**
  * Improved input validation: the goal now requires at least one of `file` or `directory` to be set.
  * Clear precedence: when `file` is provided, it’s used as the output target (otherwise `directory` is used).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->