### PR TITLE
Improve logging for NjordSessionLifecycleParticipant

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/Session.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/Session.java
@@ -108,6 +108,11 @@ public interface Session extends Closeable {
     ArtifactStore getOrCreateSessionArtifactStore(RemoteRepository repository, String uri);
 
     /**
+     * Returns the names of session-bound artifact stores created in this session.
+     */
+    Collection<String> sessionArtifactStoreNames();
+
+    /**
      * Publishes all session-bound artifact stores created in this session. Session publishes all own created
      * stores. Hence, top level session publishes all created stores in given
      * Maven session. Returns the count of published stores.

--- a/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
+++ b/core/src/main/java/eu/maveniverse/maven/njord/shared/impl/DefaultSession.java
@@ -304,6 +304,12 @@ public class DefaultSession extends CloseableConfigSupport<SessionConfig> implem
     }
 
     @Override
+    public Collection<String> sessionArtifactStoreNames() {
+        checkClosed();
+        return Collections.unmodifiableCollection(getSessionBoundStores().values());
+    }
+
+    @Override
     public int publishSessionArtifactStores() throws IOException {
         checkClosed();
         ConcurrentMap<RemoteRepository, String> sessionBoundStores = getSessionBoundStores();

--- a/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
@@ -16,6 +16,7 @@ import eu.maveniverse.maven.njord.shared.SessionFactory;
 import eu.maveniverse.maven.njord.shared.impl.J8Utils;
 import eu.maveniverse.maven.njord.shared.publisher.ArtifactStorePublisher;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -99,28 +100,38 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
                                         "Njord auto publish: Session failed; stores created in this session, if any, are not dropped");
                             }
                         } else {
-                            try {
-                                int published = njordSession.publishSessionArtifactStores();
-                                if (published != 0) {
-                                    logger.info(
-                                            "Njord auto publish: Published {} stores created in this session",
-                                            published);
-                                    if (njordSession.config().autoDrop()) {
-                                        int dropped = njordSession.dropSessionArtifactStores();
-                                        if (dropped != 0) {
+                            Collection<String> stores = njordSession.sessionArtifactStoreNames();
+                            if (stores.isEmpty()) {
+                                logger.info("Njord auto publish: No stores created in this session");
+                            } else {
+                                logger.info(
+                                        "Njord auto publish: Publishing {} stores created in this session",
+                                        stores.size());
+                                try {
+                                    int published = njordSession.publishSessionArtifactStores();
+                                    if (published != 0) {
+                                        logger.info(
+                                                "Njord auto publish: Published {} stores created in this session",
+                                                published);
+                                        if (njordSession.config().autoDrop()) {
+                                            int dropped = njordSession.dropSessionArtifactStores();
+                                            if (dropped != 0) {
+                                                logger.info(
+                                                        "Njord auto publish: Dropped {} auto published stores",
+                                                        dropped);
+                                            }
+                                        } else {
                                             logger.info(
-                                                    "Njord auto publish: Dropped {} auto published stores", dropped);
+                                                    "Njord auto publish: The {} published stores are not dropped",
+                                                    published);
                                         }
                                     } else {
                                         logger.info(
-                                                "Njord auto publish: The {} published stores are not dropped",
-                                                published);
+                                                "Njord auto publish: No stores created in this session were published");
                                     }
-                                } else {
-                                    logger.info("Njord auto publish: No stores created in this session");
+                                } catch (ArtifactStorePublisher.PublishFailedException e) {
+                                    throw new MavenExecutionException(e.getMessage(), e);
                                 }
-                            } catch (ArtifactStorePublisher.PublishFailedException e) {
-                                throw new MavenExecutionException(e.getMessage(), e);
                             }
                         }
                     }

--- a/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
@@ -105,7 +105,7 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
                                 logger.info("Njord auto publish: No stores created in this session");
                             } else {
                                 logger.info(
-                                        "Njord auto publish: Publishing {} stores created in this session",
+                                        "Njord auto publish: Publishing {} stores created in this session...",
                                         stores.size());
                                 try {
                                     int published = njordSession.publishSessionArtifactStores();

--- a/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/njord/extension3/NjordSessionLifecycleParticipant.java
@@ -88,31 +88,36 @@ public class NjordSessionLifecycleParticipant extends AbstractMavenLifecyclePart
                                 int dropped = njordSession.dropSessionArtifactStores();
                                 if (dropped != 0) {
                                     logger.warn(
-                                            "Auto publish: Session failed; dropped {} stores created in this session",
+                                            "Njord auto publish: Session failed; dropped {} stores created in this session",
                                             dropped);
                                 } else {
-                                    logger.warn("Auto publish: Session failed; no stores created in this session");
+                                    logger.warn(
+                                            "Njord auto publish: Session failed; no stores created in this session");
                                 }
                             } else {
                                 logger.warn(
-                                        "Auto publish: Session failed; stores created in this session, if any, are not dropped");
+                                        "Njord auto publish: Session failed; stores created in this session, if any, are not dropped");
                             }
                         } else {
                             try {
-                                logger.info("Auto publish: Publishing stores created in this session");
                                 int published = njordSession.publishSessionArtifactStores();
                                 if (published != 0) {
-                                    logger.info("Auto publish: Published {} stores created in this session", published);
+                                    logger.info(
+                                            "Njord auto publish: Published {} stores created in this session",
+                                            published);
                                     if (njordSession.config().autoDrop()) {
                                         int dropped = njordSession.dropSessionArtifactStores();
                                         if (dropped != 0) {
-                                            logger.info("Auto publish: Dropped {} auto published stores", dropped);
+                                            logger.info(
+                                                    "Njord auto publish: Dropped {} auto published stores", dropped);
                                         }
                                     } else {
-                                        logger.info("Auto publish: The {} published stores are not dropped", published);
+                                        logger.info(
+                                                "Njord auto publish: The {} published stores are not dropped",
+                                                published);
                                     }
                                 } else {
-                                    logger.info("Auto publish: No stores created in this session");
+                                    logger.info("Njord auto publish: No stores created in this session");
                                 }
                             } catch (ArtifactStorePublisher.PublishFailedException e) {
                                 throw new MavenExecutionException(e.getMessage(), e);


### PR DESCRIPTION
Always mention "Njord" to clarify who is responsible for emitting. Only log result of njord auto publishing.

This closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way for sessions to report the names of artifact stores created during the session.
* **Bug Fixes**
  * Refined “auto publish” logging to use clearer, consistent wording.
  * Improved session-end message formatting, including reporting when zero vs. non-zero stores are involved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->